### PR TITLE
support for cluster scope  collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ VISUS_CRDB_URL="postgresql://visus@localhost:26257/defaultdb?sslmode=disable"
 Initialize the database that contains the configuration for the collections:
 
 ```bash
-./visus collection init --url "$ADMIN_CRDB_URL" 
+./visus init --url "$ADMIN_CRDB_URL" 
 ```
 
 For this example, we use the `visus` user, with the following privileges:
@@ -189,9 +189,7 @@ Result:
 histogram latency inserted.
 ```
 
-To enable filter in the server,
-
-Start the server to enable collection of metrics from Prometheus, specify the collection endpoint with the `--promethues` flag.
+To enable filter in the server, start the server to enable collection of metrics from Prometheus, specify the collection endpoint with the `--promethues` flag.
 
 ```bash
 ./visus start --insecure --endpoint "/_status/custom"  --url "$VISUS_CRDB_URL" --prometheus "http://localhost:8080/_status/vars"
@@ -201,6 +199,25 @@ Start the server to enable collection of metrics from Prometheus, specify the co
 
 ### Collection management commands
 
+Use the `visus init` command to initialize database.
+
+```text
+Usage:
+  visus init [flags]
+
+Examples:
+./visus init  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" 
+
+Flags:
+  -h, --help         help for init
+      --url string   Connection URL, of the form: postgresql://[user[:passwd]@]host[:port]/[db][?parameters...]
+
+Global Flags:
+      --logDestination string   write logs to a file, instead of stdout
+      --logFormat string        choose log output format [ fluent, text ] (default "text")
+  -v, --verbose count           increase logging verbosity to debug; repeat for trace
+```
+
 Use the `visus collection` command to manage the collections in the database.
 
 ```text
@@ -208,12 +225,11 @@ Usage:
   visus collection [command]
 
 Available Commands:
-  delete
-  get
-  init
-  list
-  put
-  test
+  delete      
+  get         
+  list        
+  put         
+  test        
 
 Flags:
   -h, --help         help for collection
@@ -225,7 +241,7 @@ Global Flags:
   -v, --verbose count           increase logging verbosity to debug; repeat for trace
 
 Use "visus collection [command] --help" for more information about a command.
-  ```
+```
 
 ### Histogram filter management commands
 

--- a/examples/blocking_statements.yaml
+++ b/examples/blocking_statements.yaml
@@ -1,4 +1,6 @@
 name: blocking_statements
+enabled: true
+scope: cluster
 frequency: 10
 maxresults: 100
 labels: [statement]

--- a/examples/contended_tables.yaml
+++ b/examples/contended_tables.yaml
@@ -1,4 +1,6 @@
 name: contended_tables
+enabled: true
+scope: cluster
 frequency: 10
 maxresults: 100
 labels: [database_name,schema_name,table_name]
@@ -11,4 +13,6 @@ query:
       database_name, schema_name, table_name, num_contention_events as num_events
     FROM 
       crdb_internal.cluster_contended_tables
+    WHERE
+      database_name IS NOT NULL  
     LIMIT $1;

--- a/examples/index_usage.yaml
+++ b/examples/index_usage.yaml
@@ -1,5 +1,7 @@
 
 name: index
+enabled: true
+scope: cluster
 frequency: 60
 maxresults: 100
 labels: [table_name, index_name]

--- a/examples/inflight.yaml
+++ b/examples/inflight.yaml
@@ -1,5 +1,6 @@
 name: inflight
 enabled: true
+scope: node
 frequency: 10
 maxresults: 10
 labels: [user_name,application_name]

--- a/examples/intents.yaml
+++ b/examples/intents.yaml
@@ -1,4 +1,6 @@
 name: intent
+enabled: true
+scope: cluster
 frequency: 10
 maxresults: 100
 labels: [table_name]

--- a/examples/protected_ts.yaml
+++ b/examples/protected_ts.yaml
@@ -1,5 +1,6 @@
 
 name: protected_ts
+enabled: false
 frequency: 10
 maxresults: 1
 labels: []

--- a/examples/sqlactivity.yaml
+++ b/examples/sqlactivity.yaml
@@ -1,4 +1,6 @@
 name: sqlactivity
+enabled: true
+scope: node
 frequency: 10
 maxresults: 10
 labels: [statement,application,database]

--- a/examples/sqlefficiency.yaml
+++ b/examples/sqlefficiency.yaml
@@ -1,5 +1,7 @@
 
 name: sqlefficiency
+enabled: true
+scope: node
 frequency: 10
 maxresults: 10
 labels: [type]

--- a/examples/tables.yaml
+++ b/examples/tables.yaml
@@ -1,0 +1,25 @@
+name: tables
+enabled: true
+scope: cluster
+frequency: 60
+maxresults: 100
+labels: [database_name, state]
+metrics:
+  - name : num
+    kind : gauge
+    help : number of tables per database
+query:  
+  SELECT
+      database_name::string,
+      state,
+      count(*)::float as num
+  FROM
+      crdb_internal.tables
+  WHERE
+      database_name IS NOT NULL    
+  GROUP BY
+      1, 2
+  ORDER BY
+      3 DESC
+  LIMIT
+      $1;

--- a/internal/cmd/initialize/admin.go
+++ b/internal/cmd/initialize/admin.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package initialize defines the sub command to initialize the _visus database.
+package initialize
+
+import (
+	"fmt"
+
+	"github.com/cockroachlabs/visus/internal/database"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	databaseURL = ""
+)
+
+// Command inits the database.
+func Command() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "init",
+		Example: `./visus init  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := database.DefaultFactory.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			store := store.New(conn)
+			err = store.Init(ctx)
+			if err != nil {
+				fmt.Printf("Error initializing database at %s.\n", databaseURL)
+				return err
+			}
+			fmt.Printf("Database initialized at %s\n", databaseURL)
+			return nil
+		},
+	}
+	f := c.PersistentFlags()
+	f.StringVar(&databaseURL, "url", "",
+		"Connection URL, of the form: postgresql://[user[:passwd]@]host[:port]/[db][?parameters...]")
+	return c
+}

--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -41,7 +41,7 @@ func Command() *cobra.Command {
 ./visus start --bindAddr "127.0.0.1:15432" `,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			conn, err := database.New(ctx, cfg.URL)
+			conn, err := database.DefaultFactory.New(ctx, cfg.URL)
 			if err != nil {
 				return err
 			}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -256,7 +256,7 @@ func (c *collector) Collect(ctx context.Context, conn database.Connection) error
 	for rows.Next() {
 		values, err := rows.Values()
 		if err != nil {
-			log.Warnf("Collect %s", err.Error())
+			log.Warnf("%s collect %s", c.name, err.Error())
 			continue
 		}
 		labels := make([]string, len(c.labels))
@@ -266,7 +266,7 @@ func (c *collector) Collect(ctx context.Context, conn database.Connection) error
 				if value, ok := v.(string); ok {
 					labels[pos] = value
 				} else {
-					log.Errorf("Unknown type %T for label %s", v, colName)
+					log.Errorf("%s: unknown type %T for label %s", c.name, v, colName)
 				}
 			} else if _, ok := c.metrics[colName]; ok {
 				metric := c.metrics[colName]
@@ -283,7 +283,7 @@ func (c *collector) Collect(ctx context.Context, conn database.Connection) error
 						c.counterAdd(vec, metric.name, labels, floatValue)
 					case nil:
 					default:
-						log.Errorf("Unknown type %T for %s", v, metric.name)
+						log.Errorf("%s unknown type %T for %s", c.name, v, metric.name)
 					}
 				case *prometheus.GaugeVec:
 					switch value := v.(type) {
@@ -297,11 +297,11 @@ func (c *collector) Collect(ctx context.Context, conn database.Connection) error
 						c.gaugeSet(vec, metric.name, labels, floatValue)
 					case nil:
 					default:
-						log.Errorf("Unknown type %T for %s", v, metric.name)
+						log.Errorf("%s unknown type %T for %s", c.name, v, metric.name)
 					}
 				}
 			} else {
-				log.Errorf("Unknown column %s", colName)
+				log.Errorf("%s unknown column %s", c.name, colName)
 			}
 		}
 	}

--- a/internal/database/pool.go
+++ b/internal/database/pool.go
@@ -25,6 +25,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Factory creates database connections
+type Factory interface {
+	//New creates a new connection to the database.
+	New(ctx context.Context, URL string) (Connection, error)
+}
+
+type factory struct {
+}
+
+// DefaultFactory creates a pool of PGX connections.
+var DefaultFactory = &factory{}
+
 // Connection defines the methods to access the database.
 type Connection interface {
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
@@ -40,7 +52,7 @@ type Connection interface {
 
 // New creates a new connection to the database.
 // It waits until a connection can be established, or the the context has been cancelled.
-func New(ctx context.Context, URL string) (Connection, error) {
+func (f factory) New(ctx context.Context, URL string) (Connection, error) {
 	var conn *pgxpool.Pool
 	sleepTime := int64(5)
 	poolConfig, err := pgxpool.ParseConfig(URL)

--- a/internal/store/collection.go
+++ b/internal/store/collection.go
@@ -29,10 +29,10 @@ import (
 type Scope string
 
 const (
-	// Global collectors should only run on one node of the cluster.
-	Global = Scope("global")
-	// Local collectors run on all the nodes in the cluster.
-	Local = Scope("local")
+	// Cluster scope collectors should only run on one node of the cluster.
+	Cluster = Scope("cluster")
+	// Node scope collectors run on all the nodes in the cluster.
+	Node = Scope("node")
 )
 
 // Kind is the type of the metric.

--- a/internal/store/collection_test.go
+++ b/internal/store/collection_test.go
@@ -85,7 +85,7 @@ func TestGetCollection(t *testing.T) {
 			Metrics:      []Metric{},
 			Name:         "no_metrics",
 			Query:        "SELECT * FROM test limit %1",
-			Scope:        Local,
+			Scope:        Node,
 		}, false},
 		{"with_metrics", &Collection{
 			Enabled:      true,
@@ -99,7 +99,7 @@ func TestGetCollection(t *testing.T) {
 			},
 			Name:  "with_metrics",
 			Query: "SELECT * FROM test limit %1",
-			Scope: Local,
+			Scope: Node,
 		}, false},
 	}
 	for _, tt := range tests {
@@ -152,7 +152,7 @@ func TestPutCollection(t *testing.T) {
 			Metrics:      []Metric{},
 			Name:         "no_metrics",
 			Query:        "SELECT * FROM test limit %1",
-			Scope:        Local,
+			Scope:        Node,
 		}, false},
 		{"with_metrics", &Collection{
 			Enabled:      true,
@@ -166,7 +166,7 @@ func TestPutCollection(t *testing.T) {
 			},
 			Name:  "with_metrics",
 			Query: "SELECT * FROM test limit %1",
-			Scope: Local,
+			Scope: Node,
 		}, false},
 	}
 	for _, tt := range tests {

--- a/internal/store/sql/ddl.sql
+++ b/internal/store/sql/ddl.sql
@@ -1,14 +1,14 @@
 CREATE DATABASE IF NOT EXISTS _visus;
 
-CREATE ROLE IF NOT EXISTS visus_role;
-ALTER ROLE visus_role WITH VIEWACTIVITY;
-GRANT CONNECT ON DATABASE _visus to visus_role;
+CREATE USER IF NOT EXISTS visus;
+ALTER ROLE visus WITH VIEWACTIVITY;
+GRANT CONNECT ON DATABASE _visus to visus;
 
 USE _visus;
 
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO visus_monitor;
 
-CREATE TYPE IF NOT EXISTS _visus.scope AS ENUM ('local', 'global');
+CREATE TYPE IF NOT EXISTS _visus.scope AS ENUM ('node', 'cluster');
 
 CREATE TABLE IF NOT EXISTS _visus.collection (
     namespace     STRING DEFAULT '',
@@ -37,10 +37,20 @@ CREATE TABLE IF NOT EXISTS _visus.metric (
 CREATE TABLE IF NOT EXISTS _visus.histogram (
     name         STRING NOT NULL,
     regex        STRING NOT NULL,
-    updated    timestamptz DEFAULT current_timestamp (),
+    updated      timestamptz DEFAULT current_timestamp (),
     bins         INT NOT NULL,
     "start"      INT NOT NULL,
     "end"        INT NOT NULL,
     enabled      BOOL DEFAULT true,
     PRIMARY KEY (name)
 );
+
+CREATE TABLE IF NOT EXISTS _visus.node (
+    id           INT PRIMARY KEY,
+    updated      timestamptz DEFAULT current_timestamp ()
+);
+
+GRANT SELECT,INSERT,UPDATE ON TABLE _visus.node TO visus;
+GRANT SELECT ON TABLE _visus.collection TO visus;
+GRANT SELECT ON TABLE _visus.metric TO visus;
+GRANT SELECT ON TABLE _visus.histogram TO visus;

--- a/internal/store/sql/mainNode.sql
+++ b/internal/store/sql/mainNode.sql
@@ -1,0 +1,23 @@
+WITH touch as (
+UPSERT INTO
+  _visus.node 
+VALUES 
+  (crdb_internal.node_id(), current_timestamp())
+RETURNING _visus.node.*
+), nodes as (
+SELECT
+  *
+FROM
+  _visus.node 
+WHERE 
+  updated >= $1
+UNION
+SELECT
+  *
+FROM
+  touch
+)
+SELECT 
+  max(id) = crdb_internal.node_id()
+FROM 
+  nodes;

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachlabs/visus/internal/cmd/collection"
 	"github.com/cockroachlabs/visus/internal/cmd/histogram"
+	"github.com/cockroachlabs/visus/internal/cmd/initialize"
 	"github.com/cockroachlabs/visus/internal/cmd/server"
 	joonix "github.com/joonix/log"
 	"github.com/pkg/errors"
@@ -93,6 +94,7 @@ func main() {
 	root.AddCommand(server.Command())
 	root.AddCommand(collection.Command())
 	root.AddCommand(histogram.Command())
+	root.AddCommand(initialize.Command())
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()


### PR DESCRIPTION
- Adding support for cluster scope collections
- The init command is now under `visus` (previously under `visus collection`
- Support for stdio for reading yaml configuration in the `visus collection put` and `visus histogram put` commands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/19)
<!-- Reviewable:end -->
