### PR TITLE
Creating metrics from log messages.

### DIFF
--- a/examples/log.yaml
+++ b/examples/log.yaml
@@ -1,0 +1,8 @@
+name: cockroach_log
+enabled: true
+format: crdb-v2
+path: /home/ubuntu/logs/cockroach.log
+patterns:
+  - name : events
+    regex:
+    help : number of events

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/joonix/log v0.0.0-20230221083239-7988383bab32
+	github.com/nxadm/tail v1.4.11
 	github.com/pashagolub/pgxmock/v3 v3.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0
@@ -23,6 +24,11 @@ require (
 	google.golang.org/protobuf v1.34.0
 	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.4.7
+)
+
+require (
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -449,6 +449,8 @@ github.com/envoyproxy/go-control-plane v0.10.3/go.mod h1:fJJn/j26vwOu972OllsvAgJ
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-co-op/gocron v1.37.0 h1:ZYDJGtQ4OMhTLKOKMIch+/CY70Brbb1dGdooLEhh7b0=
 github.com/go-co-op/gocron v1.37.0/go.mod h1:3L/n6BkO7ABj+TrfSVXLRzsP26zmikL4ISkLQ0O8iNY=
@@ -587,6 +589,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
+github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
+github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/pashagolub/pgxmock/v3 v3.4.0 h1:87VMr2q7m2+6VzXo4Tsp9kMklGlj6mMN19Hp/bp2Rwo=
 github.com/pashagolub/pgxmock/v3 v3.4.0/go.mod h1:FvCl7xqPbLLI3XohihJ1NzXnikjM3q/NWSixg4t9hrU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -876,6 +880,7 @@ golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1210,6 +1215,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cmd/scan/admin.go
+++ b/internal/cmd/scan/admin.go
@@ -1,0 +1,320 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scan defines the sub command to run visus scan utilities.
+package scan
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/database"
+	"github.com/cockroachlabs/visus/internal/scanner"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/creasty/defaults"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var databaseURL = ""
+
+// patternDef yaml pattern definition
+type patternDef struct {
+	Help  string
+	Name  string
+	Regex string
+}
+
+// config yaml scan definition
+type config struct {
+	Enabled  bool
+	Format   string
+	Name     string
+	Path     string
+	Patterns []patternDef
+}
+
+func marshal(logFile *store.Scan) ([]byte, error) {
+	patterns := make([]patternDef, 0)
+	for _, m := range logFile.Patterns {
+		metric := patternDef{
+			Help:  m.Help,
+			Name:  m.Name,
+			Regex: m.Regex,
+		}
+		patterns = append(patterns, metric)
+	}
+	config := &config{
+		Enabled:  logFile.Enabled,
+		Format:   string(logFile.Format),
+		Name:     logFile.Name,
+		Path:     logFile.Path,
+		Patterns: patterns,
+	}
+	return yaml.Marshal(config)
+}
+
+// listCmd list all the log scans in the database
+func listCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "list",
+		Example: `./visus scan list  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := database.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			store := store.New(conn)
+			logs, err := store.GetScanNames(ctx)
+			if err != nil {
+				fmt.Print("Error retrieving log targets")
+				return err
+			}
+			for _, lg := range logs {
+				fmt.Printf("%s\n", lg)
+			}
+			return nil
+		},
+	}
+	return c
+}
+
+// getCmd retrieves a scan configuration from the database.
+func getCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "get",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan get scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			logName := args[0]
+			conn, err := database.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			store := store.New(conn)
+			scanner, err := store.GetScan(ctx, logName)
+			if err != nil {
+				fmt.Printf("Error retrieving log %s.", logName)
+				return err
+			}
+			if scanner == nil {
+				fmt.Printf("Scan %s not found\n", logName)
+			} else {
+				res, err := marshal(scanner)
+				if err != nil {
+					fmt.Printf("Unabled to marshall %s\n", logName)
+				}
+				fmt.Println(string(res))
+			}
+			return nil
+		},
+	}
+	return c
+}
+
+// testCmd retrieves a scan configuration and execute it, returning the metrics extracted
+// from the log file in the scan.
+func testCmd() *cobra.Command {
+	var interval time.Duration
+	var count int
+	c := &cobra.Command{
+		Use:     "test",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan test scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := stopper.WithContext(cmd.Context())
+			logName := args[0]
+			conn, err := database.ReadOnly(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			st := store.New(conn)
+			lg, err := st.GetScan(ctx, logName)
+			if err != nil {
+				fmt.Printf("Error retrieving scan %s.", logName)
+				return err
+			}
+			if lg == nil {
+				fmt.Printf("Scan %s not found\n", logName)
+			} else {
+				scanner, err := scanner.FromConfig(lg,
+					&scanner.Config{
+						FromBeginning: true,
+						Poll:          true,
+						Follow:        false,
+					},
+					prometheus.DefaultRegisterer)
+				if err != nil {
+					return err
+				}
+				scanner.Start(ctx)
+				for i := 1; i <= count || count == 0; i++ {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-time.After(interval):
+					}
+					gathering, err := prometheus.DefaultGatherer.Gather()
+					if err != nil {
+						fmt.Printf("Error retrieving patterns %s.", err)
+						return err
+					}
+					fmt.Printf("\n---- %s %s -----\n", time.Now().Format("01-02-2006 15:04:05"), lg.Name)
+					for _, mf := range gathering {
+						if strings.HasPrefix(*mf.Name, logName) {
+							expfmt.MetricFamilyToText(os.Stdout, mf)
+
+						}
+					}
+				}
+				return scanner.Stop()
+			}
+			return nil
+		},
+	}
+	f := c.Flags()
+	f.DurationVar(&interval, "interval", 10*time.Second, "interval of scan")
+	f.IntVar(&count, "count", 1, "number of times to run the scan. Specify 0 for continuos scan")
+	return c
+}
+
+// deleteCmd deletes a scan from the database.
+func deleteCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "delete",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan delete scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			logName := args[0]
+			conn, err := database.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			store := store.New(conn)
+			err = store.DeleteScan(ctx, args[0])
+			if err != nil {
+				fmt.Printf("Error deleting scan %s.\n", logName)
+				return err
+			}
+			fmt.Printf("Scan %s deleted.\n", logName)
+			return nil
+		},
+	}
+	return c
+}
+
+// putCmd inserts a new scan in the database using the specified yaml configuration.
+func putCmd() *cobra.Command {
+	var file string
+	c := &cobra.Command{
+		Use:     "put",
+		Args:    cobra.ExactArgs(0),
+		Example: `./visus scan put --yaml config.yaml --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if file == "" {
+				return errors.New("yaml configuration required")
+			}
+			conn, err := database.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			var data []byte
+			if file == "-" {
+				var buffer bytes.Buffer
+				scanner := bufio.NewScanner(os.Stdin)
+				for scanner.Scan() {
+					buffer.Write(scanner.Bytes())
+					buffer.WriteString("\n")
+				}
+				if err := scanner.Err(); err != nil {
+					log.Errorf("reading standard input: %s", err.Error())
+				}
+				data = buffer.Bytes()
+			} else {
+				data, err = os.ReadFile(file)
+				if err != nil {
+					return err
+				}
+			}
+			config := &config{}
+			err = yaml.Unmarshal(data, &config)
+			if err != nil {
+				return err
+			}
+			if err := defaults.Set(config); err != nil {
+				return err
+			}
+			patterns := make([]store.Pattern, 0)
+			for _, p := range config.Patterns {
+				pattern := store.Pattern{
+					Name:  p.Name,
+					Regex: p.Regex,
+					Help:  p.Help,
+				}
+				patterns = append(patterns, pattern)
+			}
+			if config.Name == "" {
+				return errors.New("name must be specified")
+			}
+			logTarget := &store.Scan{
+				Enabled:  config.Enabled,
+				Format:   store.LogFormat(config.Format),
+				Path:     config.Path,
+				Name:     config.Name,
+				Patterns: patterns,
+			}
+			store := store.New(conn)
+			err = store.PutScan(ctx, logTarget)
+			if err != nil {
+				fmt.Printf("Error inserting scan %s.", config.Name)
+				return err
+			}
+			fmt.Printf("Scan %s inserted.\n", config.Name)
+			return nil
+		},
+	}
+	f := c.Flags()
+	f.StringVar(&file, "yaml", "", "file containing the configuration")
+	return c
+}
+
+// Command runs the scan tools to view and manage the configuration in the database.
+func Command() *cobra.Command {
+	c := &cobra.Command{
+		Use: "scan",
+	}
+	f := c.PersistentFlags()
+	c.AddCommand(
+		getCmd(),
+		listCmd(),
+		deleteCmd(),
+		putCmd(),
+		testCmd())
+	f.StringVar(&databaseURL, "url", "",
+		"Connection URL, of the form: postgresql://[user[:passwd]@]host[:port]/[db][?parameters...]")
+	return c
+}

--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -25,8 +25,11 @@ import (
 	"github.com/cockroachlabs/visus/internal/database"
 	"github.com/cockroachlabs/visus/internal/http"
 	"github.com/cockroachlabs/visus/internal/metric"
+	"github.com/cockroachlabs/visus/internal/scanner"
 	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
 	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/go-co-op/gocron"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -41,13 +44,15 @@ func Command() *cobra.Command {
 		Example: `
 ./visus start --bindAddr "127.0.0.1:15432" `,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
+			ctx := stopper.WithContext(cmd.Context())
+
 			if (cfg.BindCert == "" || cfg.BindKey == "") && !cfg.Insecure {
 				return errors.New("--insecure must be specfied if certificates and private key are missing")
 			}
 			if cfg.URL == "" {
 				return errors.New("--url must be specified")
 			}
+			// Set up database connections
 			conn, err := database.New(ctx, cfg.URL)
 			if err != nil {
 				return err
@@ -57,48 +62,81 @@ func Command() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
+			// Set up Prometheus registry.
 			registry := prometheus.NewRegistry()
-
-			// Run the httpServer in a separate context, so that we can
-			// control the shutdown process.
-			httpServer, err := http.New(ctx, cfg, store, registry)
-			if err != nil {
-				return err
-			}
-			defer httpServer.Shutdown(ctx)
-			err = httpServer.Start(ctx)
-			if err != nil {
+			if err := server.RegisterMetrics(registry); err != nil {
 				return err
 			}
 
-			metricServer := metric.New(ctx, cfg, store, roConn, registry)
-			err = metricServer.Start(ctx)
+			// Start the scheduler.
+			scheduler := gocron.NewScheduler(time.UTC)
+			scheduler.StartAsync()
+			ctx.Go(func() error {
+				<-ctx.Stopping()
+				scheduler.Stop()
+				log.Info("scheduler stopped")
+				return nil
+			})
+
+			// Start the Prometheus http endpoint.
+			httpServer, err := http.New(ctx, cfg, store, registry, scheduler)
 			if err != nil {
 				return err
 			}
-			defer metricServer.Shutdown(ctx)
+			if err := httpServer.Start(ctx); err != nil {
+				return err
+			}
 
-			signalChan := make(chan os.Signal, 1)
-			signal.Notify(signalChan, syscall.SIGHUP)
+			// Start the SQL metrics collector.
+			metricServer, err := metric.New(cfg, store, roConn, registry, scheduler)
+			if err != nil {
+				return err
+			}
+			if err := metricServer.Start(ctx); err != nil {
+				return err
+			}
 
-			go func() {
+			// Start the server that manages the log scanners.
+			scannerServer := scanner.New(cfg, store, registry, scheduler)
+			if err := scannerServer.Start(ctx); err != nil {
+				return err
+			}
+
+			// Trap SIGHUP to force configuration reload.
+			sigHup := make(chan os.Signal, 1)
+			signal.Notify(sigHup, syscall.SIGHUP)
+			ctx.Go(func() error {
+				defer close(sigHup)
+				defer signal.Stop(sigHup)
 				for {
-					s := <-signalChan
-					switch s {
-					case syscall.SIGHUP:
-						log.Info("Refreshing configuration")
-						metricServer.Refresh(ctx)
-						httpServer.Refresh(ctx)
-						roConn.Refresh(ctx)
-						conn.Refresh(ctx)
+					select {
+					case <-ctx.Stopping():
+						return nil
+					case <-sigHup:
+						// We try to refresh the various configurations.
+						// If there are errors, we log them, but we
+						// try to continue with the old configuration for
+						// any server that fails.
+						log.Info("Refreshing configuration on SIGHUP")
+						if err := metricServer.Refresh(ctx); err != nil {
+							log.Errorf("refreshing metrics %q", err)
+						}
+						if err := scannerServer.Refresh(ctx); err != nil {
+							log.Errorf("refreshing scanners %q", err)
+						}
+						if err := httpServer.Refresh(ctx); err != nil {
+							log.Errorf("refreshing http  %q", err)
+						}
+						if err := roConn.Refresh(ctx); err != nil {
+							log.Errorf("refreshing read only db connection %q", err)
+						}
+						if err := conn.Refresh(ctx); err != nil {
+							log.Errorf("refreshing db connection %q", err)
+						}
 					}
 				}
-			}()
-
-			// Wait to be shut down.
-			<-ctx.Done()
-			return nil
+			})
+			return ctx.Wait()
 		},
 	}
 	f := c.Flags()
@@ -113,6 +151,7 @@ func Command() *cobra.Command {
 		"How ofter to refresh the configuration from the database.")
 	f.StringVar(&cfg.Endpoint, "endpoint", "/_status/vars",
 		"Endpoint for metrics.")
+	f.BoolVar(&cfg.Inotify, "inotify", false, "enable inotify for scans")
 	f.BoolVar(&cfg.Insecure, "insecure", false, "this flag must be set if no TLS configuration is provided")
 	f.BoolVar(&cfg.ProcMetrics, "proc-metrics", false, "enable the collection of process metrics")
 	f.BoolVar(&cfg.VisusMetrics, "visus-metrics", false, "enable the collection of visus metrics")

--- a/internal/metric/server_test.go
+++ b/internal/metric/server_test.go
@@ -1,0 +1,210 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/database"
+	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/go-co-op/gocron"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pashagolub/pgxmock/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dbQuery    = "SELECT database, count FROM databases LIMIT $1"
+	statsQuery = "SELECT statement, count FROM statements LIMIT $1"
+)
+
+func TestRefreshCollectors(t *testing.T) {
+	r := require.New(t)
+	a := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stop := stopper.WithContext(ctx)
+	conn := &mockDB{}
+	mockStore := &store.InMemory{}
+	mockStore.Init(ctx)
+	cfg := &server.Config{}
+	registry := prometheus.NewRegistry()
+	server := &metricsServer{
+		config:    cfg,
+		conn:      conn,
+		store:     mockStore,
+		scheduler: gocron.NewScheduler(time.UTC),
+		registry:  registry,
+	}
+	server.mu.stopped = true
+	server.mu.scheduledJobs = make(map[string]*scheduledJob)
+	server.scheduler.StartAsync()
+	// Adding a collection
+	dbTime := time.Now()
+	dbColl := &store.Collection{
+		Enabled: true,
+		Frequency: pgtype.Interval{
+			Microseconds: 1e6,
+			Valid:        true,
+		},
+		Labels: []string{"database"},
+		LastModified: pgtype.Timestamp{
+			Time:  dbTime,
+			Valid: true,
+		},
+		MaxResult: 1,
+		Metrics: []store.Metric{
+			{
+				Name: "count",
+				Kind: store.Counter,
+				Help: "num of databases",
+			},
+		},
+		Name:  "databases",
+		Query: dbQuery,
+	}
+	err := mockStore.PutCollection(ctx, dbColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok := server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+	// Modify the collection
+	dbTime = time.Now()
+	dbColl.LastModified.Time = dbTime
+	err = mockStore.PutCollection(ctx, dbColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+	// Add a new collection
+	sqlTime := time.Now()
+	sqlColl := &store.Collection{
+		Enabled: true,
+		Frequency: pgtype.Interval{
+			Microseconds: 1e6,
+			Valid:        true,
+		},
+		Labels: []string{"statement"},
+		LastModified: pgtype.Timestamp{
+			Time:  sqlTime,
+			Valid: true,
+		},
+		MaxResult: 1,
+		Metrics: []store.Metric{
+			{
+				Name: "count",
+				Kind: store.Counter,
+				Help: "num of statements",
+			},
+		},
+		Name:  "statements",
+		Query: statsQuery,
+	}
+	err = mockStore.PutCollection(ctx, sqlColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	sqlJob, ok := server.getJob(sqlColl.Name)
+	r.True(ok)
+	a.Equal(sqlJob.collector.GetLastModified(), sqlTime)
+	a.Equal(2, len(server.scheduler.Jobs()))
+	// Sleep just few seconds, make sure we see metrics
+	time.Sleep(2 * time.Second)
+	metrics, err := registry.Gather()
+	r.NoError(err)
+	a.Equal(2, len(metrics))
+	for _, m := range metrics {
+		a.Contains([]string{"databases_count", "statements_count"}, *m.Name)
+	}
+
+	// Remove the first collection
+	err = mockStore.DeleteCollection(ctx, dbColl.Name)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.False(ok)
+	a.Nil(coll)
+	sqlJob, ok = server.getJob(sqlColl.Name)
+	r.True(ok)
+	a.Equal(sqlJob.collector.GetLastModified(), sqlTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+
+}
+
+type mockDB struct {
+	dbcount, statscount atomic.Int32
+}
+
+var _ database.Connection = &mockDB{}
+
+// Begin implements database.Connection.
+func (m *mockDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	panic("unimplemented")
+}
+
+// Exec implements database.Connection.
+func (m *mockDB) Exec(
+	ctx context.Context, sql string, arguments ...interface{},
+) (pgconn.CommandTag, error) {
+	panic("unimplemented")
+}
+
+// Query implements database.Connection.
+func (m *mockDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	conn, err := pgxmock.NewConn()
+	if err != nil {
+		return nil, err
+	}
+	query := conn.ExpectQuery(strings.Replace(sql, "LIMIT $1", ".+", 1)).WithArgs(1)
+	switch sql {
+	case dbQuery:
+		m.dbcount.Add(1)
+		res := conn.NewRows([]string{"database", "count"})
+		res.AddRow("test", int(m.dbcount.Load()))
+		query.WillReturnRows(res)
+	case statsQuery:
+		m.statscount.Add(1)
+		res := conn.NewRows([]string{"statement", "count"})
+		res.AddRow("st1", int(m.statscount.Load()))
+		query.WillReturnRows(res)
+	}
+	return conn.Query(ctx, sql, args...)
+}
+
+// QueryRow implements database.Connection.
+func (m *mockDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	panic("unimplemented")
+}

--- a/internal/metric/testdata/pebble.log
+++ b/internal/metric/testdata/pebble.log
@@ -1,0 +1,33 @@
+I240514 21:09:45.223164 125 util/log/file_sync_buffer.go:238 ⋮ [config]   file created at: 2024/05/14 21:09:45
+I240514 21:09:45.223171 125 util/log/file_sync_buffer.go:238 ⋮ [config]   running on machine: ‹crlMBP-C02FV1N5MD6TMjk4.local›
+I240514 21:09:45.223178 125 util/log/file_sync_buffer.go:238 ⋮ [config]   binary: CockroachDB CCL v23.1.12 (x86_64-apple-darwin19, built 2023/11/09 06:34:18, go1.19.13)
+I240514 21:09:45.223183 125 util/log/file_sync_buffer.go:238 ⋮ [config]   arguments: [‹cockroach› ‹start-single-node› ‹--insecure› ‹--listen-addr=localhost:26257› ‹--http-addr=localhost:8080›]
+I240514 21:09:45.223192 125 util/log/file_sync_buffer.go:238 ⋮ [config]   log format (utf8=✓): crdb-v2
+I240514 21:09:45.223196 125 util/log/file_sync_buffer.go:238 ⋮ [config]   line format: [IWEF]yymmdd hh:mm:ss.uuuuuu goid [chan@]file:line redactionmark \[tags\] [counter] msg
+I240514 21:09:45.222952 125 3@pebble/event.go:697 ⋮ [n?,s?,pebble] 1  [JOB 1] flushing: sstable created 031355
+I240514 21:09:45.332616 125 3@pebble/event.go:689 ⋮ [n?,s?,pebble] 2  [JOB 1] MANIFEST created 031357
+I240514 21:09:45.352052 125 3@pebble/event.go:717 ⋮ [n?,s?,pebble] 3  [JOB 1] WAL created 031356
+I240514 21:09:45.392242 56 3@pebble/event.go:665 ⋮ [n?,s?,pebble] 4  [JOB 2] compacting(default) L0 [031355] (268 K) + L5 [031347 031348 031349 031350 031351 031352 031353 031354] (20 M)
+I240514 21:09:45.392453 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 5  [JOB 1] WAL deleted 031322
+I240514 21:09:45.394739 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 6  [JOB 1] WAL deleted 031335
+I240514 21:09:45.396186 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 7  [JOB 1] WAL deleted 031345
+I240514 21:09:45.401660 54 3@pebble/event.go:693 ⋮ [n?,s?,pebble] 8  [JOB 1] MANIFEST deleted 030960
+I240514 21:09:45.404496 56 3@pebble/event.go:697 ⋮ [n?,s?,pebble] 9  [JOB 2] compacting: sstable created 031359
+I240514 21:09:45.420728 27 3@pebble/event.go:709 ⋮ [n?,s?,pebble] 10  [JOB 4] all initial table stats loaded
+I240514 21:09:45.468735 125 3@pebble/event.go:689 ⋮ [n?,s?,pebble] 11  [JOB 1] MANIFEST created 000001
+I240514 21:09:45.513105 125 3@pebble/event.go:717 ⋮ [n?,s?,pebble] 12  [JOB 1] WAL created 000002
+I240514 21:09:45.582136 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 13  upgraded to format version: ‹002›
+I240514 21:09:45.647154 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 14  upgraded to format version: ‹003›
+I240514 21:09:45.684187 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 15  upgraded to format version: ‹004›
+I240514 21:09:45.723492 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 16  upgraded to format version: ‹005›
+I240514 21:09:45.743039 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 17  upgraded to format version: ‹006›
+I240514 21:09:45.762086 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 18  upgraded to format version: ‹007›
+I240514 21:09:45.782006 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 19  upgraded to format version: ‹008›
+I240514 21:09:45.802019 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 20  upgraded to format version: ‹009›
+I240514 21:09:45.821098 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 21  upgraded to format version: ‹010›
+I240514 21:09:45.861105 105 3@pebble/event.go:709 ⋮ [n?,s?,pebble] 22  [JOB 4] all initial table stats loaded
+I240514 21:09:46.047960 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 23  [JOB 2] compacting: sstable created 031360
+I240514 21:09:46.219838 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 24  [JOB 2] compacting: sstable created 031361
+I240514 21:09:46.317406 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 25  [JOB 2] compacting: sstable created 031362
+I240514 21:09:46.595958 56 3@pebble/event.go:697 ⋮ [n1,s1,pebble] 26  [JOB 2] compacting: sstable created 031363
+I240514 21:09:47.386998 56 3@pebble/event.go:697 ⋮ [n1,s1,pebble] 27  [JOB 2] compacting: sstable created 031364

--- a/internal/metric/testdata/sample.log
+++ b/internal/metric/testdata/sample.log
@@ -1,0 +1,9 @@
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8  using local environment variables:
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8 +LANG=‹en_US.UTF-8›
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8 +TERM=‹xterm-256color›
+I240418 15:31:56.563621 1 1@cli/start.go:1323 ⋮ [T1,n?] 9  process identity: ‹uid 503 euid 503 gid 20 egid 20›
+I240418 15:31:56.565946 1 1@cli/start.go:1478 ⋮ [T1,n?] 10  GEOS loaded from directory ‹/usr/local/lib/cockroach›
+I240418 15:31:56.565968 1 1@cli/start.go:779 ⋮ [T1,n?] 11  starting cockroach node
+I240418 15:31:56.801319 97 server/config.go:860 ⋮ [T1,n?] 12  1 storage engine initialized
+I240418 15:31:56.801348 97 server/config.go:863 ⋮ [T1,n?] 13  Pebble cache size: 128 MiB
+I240418 15:31:56.801363 97 server/config.go:863 ⋮ [T1,n?] 14  store 0: max size 0 B, max open file limit 117880

--- a/internal/scanner/crdbv2.go
+++ b/internal/scanner/crdbv2.go
@@ -1,0 +1,50 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/nxadm/tail"
+)
+
+var crdbPrefix = regexp.MustCompile("^[FEIW][0-9][0-9][0-9][0-9][0-9][0-9] ")
+
+// scanCockroachLog scan a cockroach log.
+func scanCockroachLog(_ context.Context, tail *tail.Tail, metrics map[string]*Metric) error {
+	for line := range tail.Lines {
+		for _, m := range metrics {
+			if !crdbPrefix.Match([]byte(line.Text)) {
+				continue
+			}
+			if m.regex.Match([]byte(line.Text)) {
+				fields := strings.Split(line.Text, " ")
+				module := ""
+				if len(fields) >= 4 {
+					_, after, found := strings.Cut(fields[3], "@")
+					if found {
+						module, _, _ = strings.Cut(after, ":")
+					} else {
+						module, _, _ = strings.Cut(fields[3], ":")
+					}
+				}
+				m.counter.WithLabelValues(string(line.Text[0]), module).Inc()
+			}
+		}
+	}
+	return nil
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,189 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scanner parses log files
+package scanner
+
+import (
+	"context"
+	"io"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/nxadm/tail"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+// Config defines the behavior of the scanner
+type Config struct {
+	Follow        bool
+	FromBeginning bool
+	Poll          bool
+	Reopen        bool
+}
+
+// Metric defines the prometheus counter to increment when a line matches the regular expression.
+type Metric struct {
+	counter *prometheus.CounterVec
+	regex   *regexp.Regexp
+}
+
+// Scanner scans a log file to extract the given metrics.
+type Scanner struct {
+	config     *Config
+	metrics    map[string]*Metric
+	registerer prometheus.Registerer
+	target     *store.Scan
+	parser     Parse
+	mu         struct {
+		sync.RWMutex
+		tail *tail.Tail
+	}
+}
+
+// Parse implements the custom logic to parse a specific log file type.
+type Parse func(context.Context, *tail.Tail, map[string]*Metric) error
+
+// FromConfig creates a new scanner, based on the configuration provided.
+func FromConfig(
+	scan *store.Scan, config *Config, registerer prometheus.Registerer,
+) (*Scanner, error) {
+	scanner := &Scanner{
+		config:     config,
+		metrics:    make(map[string]*Metric),
+		registerer: registerer,
+		target:     scan,
+	}
+	for _, p := range scan.Patterns {
+		err := scanner.addCounter(p)
+		if err != nil {
+			return nil, err
+		}
+	}
+	switch scan.Format {
+	case store.CRDBV2:
+		scanner.parser = scanCockroachLog
+	default:
+		return nil, errors.Errorf("format not supported %s", scan.Format)
+	}
+	return scanner, nil
+}
+
+// GetLastModified returns the last time the scanner configuration was updated.
+func (s *Scanner) GetLastModified() time.Time {
+	return s.target.LastModified.Time
+}
+
+// Start scanning the log
+func (s *Scanner) Start(ctx *stopper.Context) error {
+	ctx.Go(func() error {
+		tail, err := s.open()
+		if err != nil {
+			log.Errorf("Scanner %s failed. %s", s.target.Name, err.Error())
+			return errors.WithStack(err)
+		}
+		log.Infof("Scanner %s started", s.target.Name)
+		err = s.parser(ctx, tail, s.metrics)
+		if err != nil {
+			log.Errorf("Scanner %s failed. %s", s.target.Name, err.Error())
+			errors.WithStack(err)
+		}
+		return nil
+	})
+	ctx.Go(func() error {
+		<-ctx.Stopping()
+		s.Stop()
+		log.Infof("Scanner %s stopped", s.target.Name)
+		return nil
+	})
+	return nil
+}
+
+// Stop stops the scanning activity.
+func (s *Scanner) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.tail == nil {
+		return nil
+	}
+	t := s.mu.tail
+	s.mu.tail = nil
+	defer t.Cleanup()
+	return t.Stop()
+}
+
+// addCounter adds a metric counter to the Prometheus registry.
+// The counter track the number of lines matching the pattern.
+func (s *Scanner) addCounter(pattern store.Pattern) error {
+	metricName := s.target.Name + "_" + pattern.Name
+	vec := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: metricName,
+			Help: pattern.Help,
+		},
+		[]string{"level", "source"},
+	)
+	s.registerer.Unregister(vec)
+	if err := s.registerer.Register(vec); err != nil {
+		return err
+	}
+	regex, err := regexp.Compile(pattern.Regex)
+	if err != nil {
+		return err
+	}
+	log.Debugf("registering counter %s (%s)", metricName, pattern.Regex)
+	s.metrics[pattern.Name] = &Metric{
+		counter: vec,
+		regex:   regex,
+	}
+	return nil
+}
+
+// open the file for scanning
+func (s *Scanner) open() (*tail.Tail, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.tail != nil {
+		return nil, errors.Errorf("scanner already running for %s", s.target.Path)
+	}
+	var location *tail.SeekInfo
+	if !s.config.FromBeginning {
+		location = &tail.SeekInfo{
+			Offset: 0,
+			Whence: io.SeekEnd,
+		}
+	}
+	var err error
+	s.mu.tail, err = tail.TailFile(
+		s.target.Path, tail.Config{
+			Logger:   log.StandardLogger(),
+			Follow:   s.config.Follow,
+			ReOpen:   s.config.Follow,
+			Location: location,
+			Poll:     s.config.Poll,
+		})
+	return s.mu.tail, err
+}
+
+// Stopped returns true if the scanner is done.
+func (s *Scanner) stopped() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.tail == nil
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,143 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"bytes"
+	"context"
+	_ "embed" // embedding sql statements
+	"testing"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testVerify(t *testing.T, expected map[string]string) {
+	gathering, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range gathering {
+		toCheck, ok := expected[*mf.Name]
+		if ok {
+			out := bytes.NewBufferString("")
+			expfmt.MetricFamilyToText(out, mf)
+			assert.Equal(t, toCheck, out.String())
+		}
+	}
+}
+
+//go:embed testdata/all.txt
+var allExpected string
+
+//go:embed testdata/regex.txt
+var regexExpected string
+
+//go:embed testdata/max.txt
+var maxExpected string
+
+//go:embed testdata/cache.txt
+var cacheExpected string
+
+// TestScanner verifies we can produce metrics from a test file.
+func TestScanner(t *testing.T) {
+	tests := []struct {
+		name   string
+		target *store.Scan
+		want   map[string]string
+	}{
+		{
+			"all",
+			&store.Scan{
+				Enabled: true,
+				Format:  store.CRDBV2,
+				Name:    "crdb",
+				Path:    "./testdata/sample.log",
+				Patterns: []store.Pattern{
+					{
+						Name:  "all",
+						Regex: "",
+						Help:  "all events",
+					},
+				},
+			},
+			map[string]string{
+				"crdb_all": allExpected,
+			},
+		},
+		{
+			"regex",
+			&store.Scan{
+				Enabled: true,
+				Format:  store.CRDBV2,
+				Name:    "crdb",
+				Path:    "./testdata/sample.log",
+				Patterns: []store.Pattern{
+					{
+						Name:  "size",
+						Regex: "(cache|max) size",
+						Help:  "size events",
+					},
+				},
+			},
+			map[string]string{
+				"crdb_size": regexExpected,
+			},
+		},
+		{
+			"multiple regex",
+			&store.Scan{
+				Enabled: true,
+				Format:  store.CRDBV2,
+				Name:    "crdb",
+				Path:    "./testdata/sample.log",
+				Patterns: []store.Pattern{
+					{
+						Name:  "cache",
+						Regex: "cache size",
+						Help:  "cache events",
+					},
+					{
+						Name:  "max",
+						Regex: "max size",
+						Help:  "max events",
+					},
+				},
+			},
+			map[string]string{
+				"crdb_max":   maxExpected,
+				"crdb_cache": cacheExpected,
+			},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			s, err := FromConfig(tt.target, &Config{
+				FromBeginning: true,
+			}, prometheus.DefaultRegisterer)
+			r.NoError(err)
+			tail, err := s.open()
+			r.NoError(err)
+			err = s.parser(ctx, tail, s.metrics)
+			r.NoError(err)
+			testVerify(t, tt.want)
+		})
+	}
+}

--- a/internal/scanner/server.go
+++ b/internal/scanner/server.go
@@ -1,0 +1,177 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"sync"
+
+	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/go-co-op/gocron"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+type scannerServer struct {
+	config        *server.Config       // configuration
+	fromBeginning bool                 // used for testing, read logs from beginning.
+	registry      *prometheus.Registry // metrics registry
+	scheduler     *gocron.Scheduler    // the scheduler for refreshing the configuration.
+	store         store.Store          // store that contains the configuration of the scans.
+
+	mu struct {
+		sync.RWMutex
+		scanners map[string]*Scanner
+	}
+}
+
+var _ server.Server = &scannerServer{}
+
+// New returns a server that manages scanners.
+func New(
+	cfg *server.Config, store store.Store, registry *prometheus.Registry, scheduler *gocron.Scheduler,
+) server.Server {
+	scanners := &scannerServer{
+		config:    cfg,
+		registry:  registry,
+		scheduler: scheduler,
+		store:     store,
+	}
+	scanners.mu.scanners = make(map[string]*Scanner)
+	return scanners
+}
+
+// Refresh implements server.Server
+func (s *scannerServer) Refresh(ctx *stopper.Context) error {
+	log.Info("Refreshing scanners configuration")
+	err := s.refresh(ctx)
+	if err != nil {
+		server.RefreshErrors.WithLabelValues("scanners").Inc()
+	}
+	server.RefreshCounts.WithLabelValues("scanners").Inc()
+	return nil
+}
+
+// Start implements server.Server.
+func (s *scannerServer) Start(ctx *stopper.Context) error {
+	// If we don't have a scheduler, we force a refresh and we are done.
+	if s.scheduler == nil {
+		return s.Refresh(ctx)
+	}
+	_, err := s.scheduler.Every(s.config.Refresh).
+		Do(func() {
+			err := s.Refresh(ctx)
+			if err != nil {
+				log.Errorf("Error refreshing scanners %s", err.Error())
+			}
+		})
+	return err
+}
+
+// add the named scanner
+func (s *scannerServer) add(name string, scanner *Scanner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.scanners[name] = scanner
+}
+
+// buildScanner creates a new scanner.
+func (s *scannerServer) buildScanner(name string, scan *store.Scan) (*Scanner, error) {
+	scanner, err := FromConfig(scan, &Config{
+		Follow:        true,
+		FromBeginning: s.fromBeginning,
+		Poll:          !s.config.Inotify,
+		Reopen:        true,
+	}, s.registry)
+	if err != nil {
+		return nil, err
+	}
+	s.add(name, scanner)
+	return scanner, nil
+}
+
+// cleanup removes all the scanners that we don't need to keep.
+func (s *scannerServer) cleanup(toKeep map[string]bool) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, value := range s.mu.scanners {
+		if _, ok := toKeep[key]; !ok {
+			log.Infof("Removing scanner %s", key)
+			err = value.Stop()
+			if err != nil {
+				return
+			}
+			delete(s.mu.scanners, key)
+		}
+	}
+	return
+}
+
+// delete the named scanner
+func (s *scannerServer) delete(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.mu.scanners, name)
+}
+
+// get returns the named scanner.
+func (s *scannerServer) get(name string) (*Scanner, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sc, ok := s.mu.scanners[name]
+	return sc, ok
+}
+
+// refresh the scanners configuration.
+func (s *scannerServer) refresh(ctx *stopper.Context) error {
+	newScans := make(map[string]bool)
+	names, err := s.store.GetScanNames(ctx)
+	if err != nil {
+		return err
+	}
+	log.Info("Refreshing scanners")
+	for _, name := range names {
+		scan, err := s.store.GetScan(ctx, name)
+		if err != nil {
+			log.Errorf("Unable to find %s: %s", name, err.Error())
+			continue
+		}
+		log.Debugf("Considering %s; enabled=%t;", name, scan.Enabled)
+		if !scan.Enabled {
+			continue
+		}
+		newScans[name] = true
+		existing, found := s.get(name)
+		if found && !existing.GetLastModified().Before(scan.LastModified.Time) {
+			log.Debugf("Already scheduled %s, no change", scan.Name)
+			continue
+		}
+		if found {
+			log.Infof("Configuration for %s has changed", scan.Name)
+			existing.Stop()
+		}
+		scanner, err := s.buildScanner(scan.Name, scan)
+		if err != nil {
+			log.Errorf("Error adding scanner %s: %s", name, err.Error())
+			continue
+		}
+		if err := scanner.Start(ctx); err != nil {
+			s.delete(scan.Name)
+			log.Errorf("Error starting scanner %s: %s", name, err.Error())
+		}
+	}
+	return s.cleanup(newScans)
+}

--- a/internal/scanner/server_test.go
+++ b/internal/scanner/server_test.go
@@ -1,0 +1,200 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshScanners(t *testing.T) {
+	r := require.New(t)
+	a := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stopperCtx := stopper.WithContext(ctx)
+	mockStore := &store.InMemory{}
+	mockStore.Init(ctx)
+	cfg := &server.Config{}
+	registry := prometheus.NewRegistry()
+	scanners := &scannerServer{
+		config:        cfg,
+		fromBeginning: true,
+		registry:      registry,
+		store:         mockStore,
+	}
+	scanners.mu.scanners = make(map[string]*Scanner)
+
+	now := time.Now()
+	crdbScan := &store.Scan{
+		Enabled: true,
+		Format:  store.CRDBV2,
+		LastModified: pgtype.Timestamp{
+			Time:  now,
+			Valid: true,
+		},
+		Name: "crdblog",
+		Path: "./testdata/sample.log",
+		Patterns: []store.Pattern{
+			{
+				Name:  "cache",
+				Regex: "cache size",
+				Help:  "cache events",
+			},
+			{
+				Name:  "max",
+				Regex: "max size",
+				Help:  "max events",
+			},
+		},
+	}
+	// Adding the scan to the store
+	mockStore.PutScan(ctx, crdbScan)
+	// Start the scanner
+	err := scanners.Start(stopperCtx)
+	r.NoError(err)
+	// Making sure that the scan was added
+	crdbScanner, ok := scanners.get(crdbScan.Name)
+	r.True(ok)
+	a.Equal(now, crdbScanner.GetLastModified())
+	r.NoError(waitUntilRunning(ctx, crdbScanner))
+	// Waiting for the 2 metrics to show up.
+	r.NoError(waitForMetrics(ctx, registry, 2))
+	// Refresh again
+	err = scanners.Refresh(stopperCtx)
+	r.NoError(err)
+	// Making sure that the scan is still there
+	crdbScanner, ok = scanners.get(crdbScan.Name)
+	r.True(ok)
+	a.Equal(now, crdbScanner.GetLastModified())
+	// Updating the scan
+	now = time.Now()
+	crdbScan.LastModified.Time = now
+	mockStore.PutScan(ctx, crdbScan)
+	// Refresh
+	err = scanners.Refresh(stopperCtx)
+	r.NoError(err)
+	// Making sure that the scan was updated
+	crdbScanner, ok = scanners.get(crdbScan.Name)
+	r.True(ok)
+	a.Equal(now, crdbScanner.GetLastModified())
+
+	// Adding another scan
+	pebbleTime := time.Now()
+	pebbleScan := &store.Scan{
+		Enabled: true,
+		Format:  store.CRDBV2,
+		LastModified: pgtype.Timestamp{
+			Time:  pebbleTime,
+			Valid: true,
+		},
+		Name: "pebble",
+		Path: "./testdata/pebble.log",
+		Patterns: []store.Pattern{
+			{
+				Name:  "sstable",
+				Regex: "sstable",
+				Help:  "sstable events",
+			},
+		},
+	}
+
+	// Adding the scan to the store
+	mockStore.PutScan(ctx, pebbleScan)
+
+	// Refresh
+	err = scanners.Refresh(stopperCtx)
+	r.NoError(err)
+
+	// Making sure that the crdb scan is still there
+	crdbScanner, ok = scanners.get(crdbScan.Name)
+	r.True(ok)
+	a.Equal(now, crdbScanner.GetLastModified())
+	r.NoError(waitUntilRunning(ctx, crdbScanner))
+	// Making sure that the pebble scan  there
+	pebbleScanner, ok := scanners.get(pebbleScan.Name)
+	r.True(ok)
+	a.Equal(pebbleTime, pebbleScanner.GetLastModified())
+	r.NoError(waitUntilRunning(ctx, pebbleScanner))
+	// Waiting for the additional metric to show up.
+	r.NoError(waitForMetrics(ctx, registry, 3))
+
+	// Removing the crdb log scanner
+	mockStore.DeleteScan(ctx, crdbScan.Name)
+	// Refresh
+	err = scanners.Refresh(stopperCtx)
+	r.NoError(err)
+
+	// Making sure that the crdb scanner is stopped, and pebble is not
+	r.True(crdbScanner.stopped())
+	r.False(pebbleScanner.stopped())
+
+	// Making sure that the crdb scanner is gone
+	crdbScanner, ok = scanners.get(crdbScan.Name)
+	a.False(ok)
+	a.Nil(crdbScanner)
+
+	// Making sure that the pebble scan  there
+	pebbleScanner, ok = scanners.get(pebbleScan.Name)
+	r.True(ok)
+	a.Equal(pebbleTime, pebbleScanner.GetLastModified())
+
+	// Verify that we collected metrics
+	metrics, err := registry.Gather()
+	r.NoError(err)
+	a.Equal(3, len(metrics))
+	for _, m := range metrics {
+		a.Contains([]string{"crdblog_cache", "crdblog_max", "pebble_sstable"}, *m.Name)
+	}
+
+}
+
+func waitForMetrics(ctx context.Context, registry *prometheus.Registry, expected int) error {
+	for {
+		metrics, err := registry.Gather()
+		if err != nil {
+			return err
+		}
+		if len(metrics) == expected {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.Tick(time.Second):
+		}
+	}
+
+}
+func waitUntilRunning(ctx context.Context, scanner *Scanner) error {
+	for scanner.stopped() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.Tick(time.Second):
+		}
+	}
+	return nil
+}

--- a/internal/scanner/testdata/all.txt
+++ b/internal/scanner/testdata/all.txt
@@ -1,0 +1,4 @@
+# HELP crdb_all all events
+# TYPE crdb_all counter
+crdb_all{level="I",source="cli/start.go"} 6
+crdb_all{level="I",source="server/config.go"} 3

--- a/internal/scanner/testdata/cache.txt
+++ b/internal/scanner/testdata/cache.txt
@@ -1,0 +1,3 @@
+# HELP crdb_cache cache events
+# TYPE crdb_cache counter
+crdb_cache{level="I",source="server/config.go"} 1

--- a/internal/scanner/testdata/max.txt
+++ b/internal/scanner/testdata/max.txt
@@ -1,0 +1,3 @@
+# HELP crdb_max max events
+# TYPE crdb_max counter
+crdb_max{level="I",source="server/config.go"} 1

--- a/internal/scanner/testdata/pebble.log
+++ b/internal/scanner/testdata/pebble.log
@@ -1,0 +1,33 @@
+I240514 21:09:45.223164 125 util/log/file_sync_buffer.go:238 ⋮ [config]   file created at: 2024/05/14 21:09:45
+I240514 21:09:45.223171 125 util/log/file_sync_buffer.go:238 ⋮ [config]   running on machine: ‹crlMBP-C02FV1N5MD6TMjk4.local›
+I240514 21:09:45.223178 125 util/log/file_sync_buffer.go:238 ⋮ [config]   binary: CockroachDB CCL v23.1.12 (x86_64-apple-darwin19, built 2023/11/09 06:34:18, go1.19.13)
+I240514 21:09:45.223183 125 util/log/file_sync_buffer.go:238 ⋮ [config]   arguments: [‹cockroach› ‹start-single-node› ‹--insecure› ‹--listen-addr=localhost:26257› ‹--http-addr=localhost:8080›]
+I240514 21:09:45.223192 125 util/log/file_sync_buffer.go:238 ⋮ [config]   log format (utf8=✓): crdb-v2
+I240514 21:09:45.223196 125 util/log/file_sync_buffer.go:238 ⋮ [config]   line format: [IWEF]yymmdd hh:mm:ss.uuuuuu goid [chan@]file:line redactionmark \[tags\] [counter] msg
+I240514 21:09:45.222952 125 3@pebble/event.go:697 ⋮ [n?,s?,pebble] 1  [JOB 1] flushing: sstable created 031355
+I240514 21:09:45.332616 125 3@pebble/event.go:689 ⋮ [n?,s?,pebble] 2  [JOB 1] MANIFEST created 031357
+I240514 21:09:45.352052 125 3@pebble/event.go:717 ⋮ [n?,s?,pebble] 3  [JOB 1] WAL created 031356
+I240514 21:09:45.392242 56 3@pebble/event.go:665 ⋮ [n?,s?,pebble] 4  [JOB 2] compacting(default) L0 [031355] (268 K) + L5 [031347 031348 031349 031350 031351 031352 031353 031354] (20 M)
+I240514 21:09:45.392453 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 5  [JOB 1] WAL deleted 031322
+I240514 21:09:45.394739 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 6  [JOB 1] WAL deleted 031335
+I240514 21:09:45.396186 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 7  [JOB 1] WAL deleted 031345
+I240514 21:09:45.401660 54 3@pebble/event.go:693 ⋮ [n?,s?,pebble] 8  [JOB 1] MANIFEST deleted 030960
+I240514 21:09:45.404496 56 3@pebble/event.go:697 ⋮ [n?,s?,pebble] 9  [JOB 2] compacting: sstable created 031359
+I240514 21:09:45.420728 27 3@pebble/event.go:709 ⋮ [n?,s?,pebble] 10  [JOB 4] all initial table stats loaded
+I240514 21:09:45.468735 125 3@pebble/event.go:689 ⋮ [n?,s?,pebble] 11  [JOB 1] MANIFEST created 000001
+I240514 21:09:45.513105 125 3@pebble/event.go:717 ⋮ [n?,s?,pebble] 12  [JOB 1] WAL created 000002
+I240514 21:09:45.582136 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 13  upgraded to format version: ‹002›
+I240514 21:09:45.647154 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 14  upgraded to format version: ‹003›
+I240514 21:09:45.684187 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 15  upgraded to format version: ‹004›
+I240514 21:09:45.723492 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 16  upgraded to format version: ‹005›
+I240514 21:09:45.743039 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 17  upgraded to format version: ‹006›
+I240514 21:09:45.762086 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 18  upgraded to format version: ‹007›
+I240514 21:09:45.782006 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 19  upgraded to format version: ‹008›
+I240514 21:09:45.802019 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 20  upgraded to format version: ‹009›
+I240514 21:09:45.821098 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 21  upgraded to format version: ‹010›
+I240514 21:09:45.861105 105 3@pebble/event.go:709 ⋮ [n?,s?,pebble] 22  [JOB 4] all initial table stats loaded
+I240514 21:09:46.047960 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 23  [JOB 2] compacting: sstable created 031360
+I240514 21:09:46.219838 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 24  [JOB 2] compacting: sstable created 031361
+I240514 21:09:46.317406 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 25  [JOB 2] compacting: sstable created 031362
+I240514 21:09:46.595958 56 3@pebble/event.go:697 ⋮ [n1,s1,pebble] 26  [JOB 2] compacting: sstable created 031363
+I240514 21:09:47.386998 56 3@pebble/event.go:697 ⋮ [n1,s1,pebble] 27  [JOB 2] compacting: sstable created 031364

--- a/internal/scanner/testdata/regex.txt
+++ b/internal/scanner/testdata/regex.txt
@@ -1,0 +1,3 @@
+# HELP crdb_size size events
+# TYPE crdb_size counter
+crdb_size{level="I",source="server/config.go"} 2

--- a/internal/scanner/testdata/sample.log
+++ b/internal/scanner/testdata/sample.log
@@ -1,0 +1,9 @@
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8  using local environment variables:
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8 +LANG=‹en_US.UTF-8›
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8 +TERM=‹xterm-256color›
+I240418 15:31:56.563621 1 1@cli/start.go:1323 ⋮ [T1,n?] 9  process identity: ‹uid 503 euid 503 gid 20 egid 20›
+I240418 15:31:56.565946 1 1@cli/start.go:1478 ⋮ [T1,n?] 10  GEOS loaded from directory ‹/usr/local/lib/cockroach›
+I240418 15:31:56.565968 1 1@cli/start.go:779 ⋮ [T1,n?] 11  starting cockroach node
+I240418 15:31:56.801319 97 server/config.go:860 ⋮ [T1,n?] 12  1 storage engine initialized
+I240418 15:31:56.801348 97 server/config.go:863 ⋮ [T1,n?] 13  Pebble cache size: 128 MiB
+I240418 15:31:56.801363 97 server/config.go:863 ⋮ [T1,n?] 14  store 0: max size 0 B, max open file limit 117880

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -16,18 +16,19 @@ package server
 
 import "time"
 
-// Config encapsulates the command-line configurations and the logic
-// necessary to make those values usable.
+// Config encapsulates the command-line parameters that can be supplied
+// to configure the behavior of Visus.
 type Config struct {
 	BindAddr          string        // Address to bind the server to.
 	BindCert, BindKey string        // Paths to Certificate and Key.
 	CaCert            string        // Path to the Root CA.
 	Endpoint          string        // Endpoint for metrics
-	RewriteHistograms bool          // Enable histogram rewriting
+	Inotify           bool          // Enable inotify for scans.
 	Insecure          bool          // Sanity check to ensure that the operator really means it.
+	ProcMetrics       bool          // Enable collections of process metrics.
 	Prometheus        string        // URL for the node prometheus endpoint
 	Refresh           time.Duration // how often to refresh the configuration.
+	RewriteHistograms bool          // Enable histogram rewriting
 	URL               string        // URL to connect to the database
-	ProcMetrics       bool          // Enable collections of process metrics.
-	VisusMetrics      bool          // Enable collection of visus metrics.
+	VisusMetrics      bool          // Enable collection of Visus metrics.
 }

--- a/internal/stopper/stopper.go
+++ b/internal/stopper/stopper.go
@@ -1,0 +1,322 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stopper contains a utility class for gracefully terminating
+// long-running processes.A
+// Origin: https://github.com/cockroachdb/replicator/tree/master/internal/util/stopper
+// TODO (silvano): Move to the field engineering tools library repo.
+package stopper
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// contextKey is a [context.Context.Value] key.
+type contextKey struct{}
+
+// background is a Context that never stops.
+var background = &Context{
+	delegate: context.Background(),
+	stopping: make(chan struct{}),
+}
+
+// ErrStopped will be returned from [context.Cause] when the Context has
+// been stopped.
+var ErrStopped = errors.New("stopped")
+
+// ErrGracePeriodExpired will be returned from [context.Cause] when the
+// Context has been stopped, but the goroutines have not exited.
+var ErrGracePeriodExpired = errors.New("grace period expired")
+
+// A Context is conceptually similar to an [errgroup.Group] in that it
+// manages a [context.Context] whose lifecycle is associated with some
+// number of goroutines. Rather than canceling the associated context
+// when a goroutine returns an error, it cancels the context after the
+// Stop method is called and all associated goroutines have all exited.
+//
+// As an API convenience, the Context type implements [context.Context]
+// so that it fits into idiomatic context-plumbing.  The [From]
+// function can be used to retrieve a Context from any
+// [context.Context].
+type Context struct {
+	cancel   func(error) // Invoked via cancelLocked.
+	delegate context.Context
+	stopping chan struct{}
+	parent   *Context
+
+	mu struct {
+		sync.RWMutex
+		count    int
+		deferred []func()
+		err      error
+		stopping bool
+	}
+}
+
+var _ context.Context = (*Context)(nil)
+
+// Background is analogous to [context.Background]. It returns a Context
+// which cannot be stopped or canceled, but which is otherwise
+// functional.
+func Background() *Context { return background }
+
+// From returns a pre-existing Context from the Context chain. Use
+// [WithContext] to construct a new Context.
+//
+// If the chain is not associated with a Context, the [Background]
+// instance will be returned.
+func From(ctx context.Context) *Context {
+	if s, ok := ctx.(*Context); ok {
+		return s
+	}
+	if s := ctx.Value(contextKey{}); s != nil {
+		return s.(*Context)
+	}
+	return Background()
+}
+
+// IsStopping is a convenience method to determine if a stopper is
+// associated with a Context and if work should be stopped.
+func IsStopping(ctx context.Context) bool {
+	return From(ctx).IsStopping()
+}
+
+// WithContext creates a new Context whose work will be immediately
+// canceled when the parent context is canceled. If the provided context
+// is already managed by a Context, a call to the enclosing
+// [Context.Stop] method will also trigger a call to Stop in the
+// newly-constructed Context.
+func WithContext(ctx context.Context) *Context {
+	// Might be background, which never stops.
+	parent := From(ctx)
+
+	ctx, cancel := context.WithCancelCause(ctx)
+	s := &Context{
+		cancel:   cancel,
+		delegate: ctx,
+		parent:   parent,
+		stopping: make(chan struct{}),
+	}
+
+	// Propagate a parent stop or context cancellation into a Stop call
+	// to ensure that all notification channels are closed.
+	go func() {
+		select {
+		case <-parent.Stopping():
+		case <-s.Done():
+		}
+		s.Stop(0)
+	}()
+	return s
+}
+
+// Deadline implements [context.Context].
+func (s *Context) Deadline() (deadline time.Time, ok bool) { return s.delegate.Deadline() }
+
+// Defer registers a callback that will be executed after the
+// [Context.Done] channel is closed. This method can be used to clean up
+// resources that are used by goroutines associated with the Context
+// (e.g. closing database connections). The Context will already have
+// been canceled by the time the callback is run, so its behaviors
+// should be associated with a background context. Callbacks will be
+// executed in a LIFO manner. If the context has already stopped, the
+// callback will be executed immediately.
+//
+// Calling this method on the Background context will panic, since that
+// context can never be cancelled.
+func (s *Context) Defer(fn func()) {
+	if s == background {
+		panic(errors.New("cannot call Context.Defer() on a background context"))
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Err() != nil {
+		fn()
+		return
+	}
+	s.mu.deferred = append(s.mu.deferred, fn)
+}
+
+// Done implements [context.Context]. The channel that is returned will
+// be closed when Stop has been called and all associated goroutines
+// have exited. The returned channel will be closed immediately if the
+// parent context (passed to [WithContext]) is canceled. Functions
+// passed to [Context.Go] should prefer [Context.Stopping] instead.
+func (s *Context) Done() <-chan struct{} { return s.delegate.Done() }
+
+// Err implements context.Context. When the return value for this is
+// [context.ErrCanceled], [context.Cause] will return [ErrStopped] if
+// the context cancellation resulted from a call to Stop.
+func (s *Context) Err() error { return s.delegate.Err() }
+
+// Go spawns a new goroutine to execute the given function and monitors
+// its lifecycle.
+//
+// If the function returns an error, the Stop method will be called. The
+// returned error will be available from Wait once the remaining
+// goroutines have exited.
+//
+// This method will not execute the function and return false if Stop
+// has already been called.
+//
+// The function passed to Go should prefer the [Context.Stopping]
+// channel to return instead of depending on [Context.Done]. This allows
+// a soft-stop, rather than waiting for the grace period to expire when
+// [Context.Stop] is called.
+func (s *Context) Go(fn func() error) (accepted bool) {
+	if !s.apply(1) {
+		return false
+	}
+
+	go func() {
+		defer s.apply(-1)
+		if err := fn(); err != nil {
+			s.Stop(0)
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			if s.mu.err == nil {
+				s.mu.err = err
+			}
+		}
+	}()
+	return true
+}
+
+// IsStopping returns true once [Stop] has been called.  See also
+// [Stopping] for a notification-based API.
+func (s *Context) IsStopping() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.stopping
+}
+
+// Stop begins a graceful shutdown of the Context. When this method is
+// called, the Stopping channel will be closed.  Once all goroutines
+// started by Go have exited, the associated Context will be cancelled,
+// thus closing the Done channel. If the gracePeriod is non-zero, the
+// context will be forcefully cancelled if the goroutines have not
+// exited within the given timeframe.
+func (s *Context) Stop(gracePeriod time.Duration) {
+	if s == background {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.mu.stopping {
+		return
+	}
+	s.mu.stopping = true
+	close(s.stopping)
+
+	// Cancel the context if nothing's currently running.
+	if s.mu.count == 0 {
+		s.cancelLocked(ErrStopped)
+	} else if gracePeriod > 0 {
+		go func() {
+			select {
+			case <-time.After(gracePeriod):
+				// Cancel after the grace period has expired. This
+				// should immediately terminate any well-behaved
+				// goroutines driven by Go().
+				s.mu.Lock()
+				defer s.mu.Unlock()
+				s.cancelLocked(ErrGracePeriodExpired)
+			case <-s.Done():
+				// We'll hit this path in a clean-exit, where apply()
+				// cancels the context after the last goroutine has
+				// exited.
+			}
+		}()
+	}
+}
+
+// Stopping returns a channel that is closed when a graceful shutdown
+// has been requested or when the parent context has been canceled.
+func (s *Context) Stopping() <-chan struct{} {
+	return s.stopping
+}
+
+// Value implements context.Context.
+func (s *Context) Value(key any) any {
+	if _, ok := key.(contextKey); ok {
+		return s
+	}
+	return s.delegate.Value(key)
+}
+
+// Wait will block until Stop has been called and all associated
+// goroutines have exited or the parent context has been cancelled. This
+// method will return the first, non-nil error from any of the callbacks
+// passed to Go. If Wait is called on the [Background] instance, it will
+// immediately return nil.
+func (s *Context) Wait() error {
+	if s == background {
+		return nil
+	}
+	<-s.Done()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.err
+}
+
+// apply is used to maintain the count of started goroutines. It returns
+// true if the delta was applied.
+func (s *Context) apply(delta int) bool {
+	if s == background {
+		return true
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Don't allow new goroutines to be added when stopping.
+	if s.mu.stopping && delta >= 0 {
+		return false
+	}
+
+	// Ensure that nested jobs prolong the lifetime of the parent
+	// context to prevent premature cancellation. Verify that the parent
+	// accepted the delta in case it was just stopped, but our helper
+	// goroutine hasn't yet called Stop on this instance.
+	if !s.parent.apply(delta) {
+		return false
+	}
+
+	s.mu.count += delta
+	if s.mu.count < 0 {
+		// Implementation error, not user problem.
+		panic("over-released")
+	}
+	if s.mu.count == 0 && s.mu.stopping {
+		s.cancelLocked(ErrStopped)
+	}
+	return true
+}
+
+// cancelLocked invokes the context-cancellation function and then
+// executes any deferred callbacks.
+func (s *Context) cancelLocked(err error) {
+	s.cancel(err)
+	for i := len(s.mu.deferred) - 1; i >= 0; i-- {
+		s.mu.deferred[i]()
+	}
+	s.mu.deferred = nil
+}

--- a/internal/stopper/stopper_test.go
+++ b/internal/stopper/stopper_test.go
@@ -1,0 +1,247 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stopper
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAmbient(t *testing.T) {
+	a := assert.New(t)
+
+	s := From(context.Background())
+	a.Same(s, background)
+
+	a.False(IsStopping(context.Background()))
+	s.Go(func() error { return nil })
+
+	// Should be a no-op.
+	s.Stop(0)
+	a.False(s.mu.stopping)
+	a.Nil(s.Err())
+	a.Nil(s.Wait())
+}
+
+func TestCancelOuter(t *testing.T) {
+	a := assert.New(t)
+
+	top, cancelTop := context.WithCancel(context.Background())
+
+	s := WithContext(top)
+
+	s.Go(func() error { <-s.Done(); return nil })
+
+	cancelTop()
+	select {
+	case <-s.Stopping():
+	// Verify that canceling the top-level also closes the Stopping channel.
+	case <-time.After(time.Second):
+		a.Fail("timed out waiting for Stopping to close")
+	}
+	a.True(IsStopping(s))
+	a.ErrorIs(s.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(s), context.Canceled)
+	a.Nil(s.Wait())
+}
+
+func TestCallbackErrorStops(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	err := errors.New("BOOM")
+	s.Go(func() error { return err })
+	a.ErrorIs(s.Wait(), err)
+	a.Error(context.Cause(s), ErrStopped)
+}
+
+func TestChainStopper(t *testing.T) {
+	a := assert.New(t)
+
+	parent := WithContext(context.Background())
+	mid := context.WithValue(parent, parent, parent) // Demonstrate unwrapping.
+	child := WithContext(mid)
+	a.Same(parent, child.parent)
+
+	waitFor := make(chan struct{})
+	child.Go(func() error { <-waitFor; return nil })
+
+	// Verify that stopping the parent propagates to the child.
+	parent.Stop(0)
+	select {
+	case <-child.Stopping():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("call to stop did not propagate")
+	}
+
+	// However, the contexts should not cancel until the work is done.
+	a.Nil(parent.Err())
+	a.Nil(child.Err())
+
+	// Allow the work to finish, and verify cancellation.
+	close(waitFor)
+
+	select {
+	case <-child.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for child to finish")
+	}
+
+	select {
+	case <-mid.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for mid to finish")
+	}
+
+	select {
+	case <-parent.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for parent to finish")
+	}
+
+	a.ErrorIs(child.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(child), ErrStopped)
+	a.Nil(child.Wait())
+
+	a.ErrorIs(mid.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(mid), ErrStopped)
+
+	a.ErrorIs(parent.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(parent), ErrStopped)
+	a.Nil(child.Wait())
+}
+
+func TestDefer(t *testing.T) {
+	a := assert.New(t)
+
+	var mu sync.Mutex
+	var calls []string
+	recordCall := func(s string) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, s)
+	}
+
+	s := WithContext(context.Background())
+	s.Defer(func() { recordCall("fifo_a") })
+	s.Defer(func() { recordCall("fifo_b") })
+	s.Go(func() error {
+		recordCall("fifo_c")
+		s.Stop(time.Second)
+		return nil
+	})
+	a.Nil(s.Wait())
+	s.Defer(func() { recordCall("immediate_a") })
+	s.Defer(func() { recordCall("immediate_b") })
+
+	mu.Lock()
+	defer mu.Unlock()
+	a.Equal([]string{"fifo_c", "fifo_b", "fifo_a", "immediate_a", "immediate_b"}, calls)
+
+	a.PanicsWithError("cannot call Context.Defer() on a background context", func() {
+		Background().Defer(func() {})
+	})
+}
+
+func TestGracePeriod(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+
+	// This goroutine waits on Done, which is not correct.
+	s.Go(func() error { <-s.Done(); return nil })
+
+	s.Stop(time.Nanosecond)
+
+	<-s.Done()
+	a.ErrorIs(s.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(s), ErrGracePeriodExpired)
+}
+
+func TestStopper(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	a.Same(s, From(s))                          // Direct cast
+	a.Same(s, From(context.WithValue(s, s, s))) // Unwrapping
+	select {
+	case <-s.Stopping():
+		a.Fail("should not be stopping yet")
+	default:
+		// OK
+	}
+	a.False(IsStopping(s))
+
+	waitFor := make(chan struct{})
+	a.True(s.Go(func() error { <-waitFor; return nil }))
+	a.True(s.Go(func() error { return nil }))
+
+	s.Stop(0)
+	select {
+	case <-s.Stopping():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for stopped")
+	}
+
+	// Verify that the context is stopping, but not cancelled.
+	a.True(IsStopping(s))
+	a.Nil(s.Err())
+
+	// It's a no-op to run new routines after stopping.
+	a.False(s.Go(func() error { return nil }))
+
+	// Stop the waiting goroutines.
+	close(waitFor)
+
+	// Once all workers have stopped, the context should cancel.
+	select {
+	case <-s.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for Context.Done()")
+	}
+	a.True(IsStopping(s))
+	a.NotNil(s.Err())
+	a.ErrorIs(context.Cause(s), ErrStopped)
+	a.Nil(s.Wait())
+}
+
+// Verify that a never-used Stopper behaves correctly.
+func TestUnused(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	s.Stop(0)
+	select {
+	case <-s.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for Context.Done()")
+	}
+	a.ErrorIs(context.Cause(s), ErrStopped)
+	a.Nil(s.Wait())
+}

--- a/internal/store/histogram.go
+++ b/internal/store/histogram.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	_ "embed" // embedding sql statements
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	log "github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 )
 
 // Histogram stores the properties for a histogram definition.
@@ -49,59 +50,38 @@ var deleteHistogramStmt string
 
 // DeleteHistogram removes a histogram configuration from the database.
 func (s *store) DeleteHistogram(ctx context.Context, regex string) error {
-	txn, err := s.conn.Begin(ctx)
-	if err != nil {
-		log.Debugln(err)
-		return err
-	}
-	defer txn.Commit(ctx)
-	_, err = txn.Exec(ctx, deleteHistogramStmt, regex)
-	if err != nil {
-		log.Errorf("delete histogram error:%s", err)
-		txn.Rollback(ctx)
-		return err
-	}
-	return nil
+	_, err := s.conn.Exec(ctx, deleteHistogramStmt, regex)
+	return err
 }
 
 // GetHistograms retrieves all the histograms stored in the database.
 func (s *store) GetHistogram(ctx context.Context, name string) (*Histogram, error) {
-	rows, err := s.conn.Query(ctx, getHistogramStmt, name)
-	if err != nil {
-		log.Errorf("GetHistogram %s ", err.Error())
-		return nil, err
-	}
-	defer rows.Close()
-	if rows.Next() {
-		histogram := &Histogram{}
-		err := rows.Scan(
-			&histogram.Name, &histogram.Regex,
-			&histogram.LastModified, &histogram.Enabled,
-			&histogram.Bins, &histogram.Start, &histogram.End)
-		if err != nil {
-			log.Debugln(err)
-			return nil, err
+	row := s.conn.QueryRow(ctx, getHistogramStmt, name)
+	histogram := &Histogram{}
+	if err := row.Scan(
+		&histogram.Name, &histogram.Regex,
+		&histogram.LastModified, &histogram.Enabled,
+		&histogram.Bins, &histogram.Start, &histogram.End); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
 		}
-		return histogram, nil
+		return nil, errors.WithStack(err)
 	}
-	return nil, err
+	return histogram, nil
 }
 
 // GetHistograms retrieves all the histograms stored in the database.
 func (s *store) GetHistogramNames(ctx context.Context) ([]string, error) {
 	rows, err := s.conn.Query(ctx, listHistogramsStmt)
 	if err != nil {
-		log.Errorf("GetHistogramNames %s ", err.Error())
 		return nil, err
 	}
 	defer rows.Close()
 	res := make([]string, 0)
-
 	for rows.Next() {
 		var name string
 		err := rows.Scan(&name)
 		if err != nil {
-			log.Debugln(err)
 			return nil, err
 		}
 		res = append(res, name)
@@ -112,21 +92,9 @@ func (s *store) GetHistogramNames(ctx context.Context) ([]string, error) {
 // PutHistogram adds a new histogram configuration to the database.
 // If a histogram with the same regex already exists, it is replaced.
 func (s *store) PutHistogram(ctx context.Context, histogram *Histogram) error {
-	log.Debugf("%+v", histogram)
-	txn, err := s.conn.Begin(ctx)
-	if err != nil {
-		log.Debugln(err)
-		return err
-	}
-	defer txn.Commit(ctx)
-	_, err = txn.Exec(ctx, upsertHistogramStmt,
+	_, err := s.conn.Exec(ctx, upsertHistogramStmt,
 		histogram.Name,
 		histogram.Regex, histogram.Bins,
 		histogram.Start, histogram.End)
-	if err != nil {
-		log.Errorf("upsert histogram error:%s, %s", upsertHistogramStmt, err)
-		txn.Rollback(ctx)
-		return err
-	}
-	return nil
+	return err
 }

--- a/internal/store/inmemory.go
+++ b/internal/store/inmemory.go
@@ -1,0 +1,134 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// InMemory stores the configuration in memory. Used for testing.
+type InMemory struct {
+	MainNode    bool
+	collections *sync.Map
+	histograms  *sync.Map
+	scans       *sync.Map
+}
+
+var _ Store = &InMemory{}
+
+// DeleteCollection implements store.Store.
+func (m *InMemory) DeleteCollection(_ context.Context, name string) error {
+	m.collections.Delete(name)
+	return nil
+}
+
+// DeleteHistogram implements store.Store.
+func (m *InMemory) DeleteHistogram(_ context.Context, name string) error {
+	m.histograms.Delete(name)
+	return nil
+}
+
+// DeleteScan implements store.Store.
+func (m *InMemory) DeleteScan(_ context.Context, name string) error {
+	m.scans.Delete(name)
+	return nil
+}
+
+// GetCollection implements store.Store.
+func (m *InMemory) GetCollection(_ context.Context, name string) (*Collection, error) {
+	res, _ := m.collections.Load(name)
+	return res.(*Collection), nil
+}
+
+// GetCollectionNames implements store.Store.
+func (m *InMemory) GetCollectionNames(_ context.Context) ([]string, error) {
+	return getNames(m.collections)
+}
+
+// GetHistogram implements store.Store.
+func (m *InMemory) GetHistogram(_ context.Context, name string) (*Histogram, error) {
+	res, _ := m.histograms.Load(name)
+	return res.(*Histogram), nil
+}
+
+// GetHistogramNames implements store.Store.
+func (m *InMemory) GetHistogramNames(_ context.Context) ([]string, error) {
+	return getNames(m.histograms)
+}
+
+// GetMetrics implements store.Store.
+func (m *InMemory) GetMetrics(ctx context.Context, name string) ([]Metric, error) {
+	coll, _ := m.GetCollection(ctx, name)
+	return coll.Metrics, nil
+}
+
+// GetScan implements store.Store.
+func (m *InMemory) GetScan(_ context.Context, name string) (*Scan, error) {
+	res, _ := m.scans.Load(name)
+	return res.(*Scan), nil
+}
+
+// GetScanNames implements store.Store.
+func (m *InMemory) GetScanNames(_ context.Context) ([]string, error) {
+	return getNames(m.scans)
+}
+
+// GetScanPatterns implements store.Store.
+func (m *InMemory) GetScanPatterns(ctx context.Context, name string) ([]Pattern, error) {
+	scan, _ := m.GetScan(ctx, name)
+	return scan.Patterns, nil
+}
+
+// Init implements store.Store.
+func (m *InMemory) Init(_ context.Context) error {
+	m.collections = &sync.Map{}
+	m.histograms = &sync.Map{}
+	m.scans = &sync.Map{}
+	return nil
+}
+
+// IsMainNode implements store.Store.
+func (m *InMemory) IsMainNode(_ context.Context, lastUpdated time.Time) (bool, error) {
+	return m.MainNode, nil
+}
+
+// PutCollection implements store.Store.
+func (m *InMemory) PutCollection(_ context.Context, collection *Collection) error {
+	m.collections.Store(collection.Name, collection)
+	return nil
+}
+
+// PutHistogram implements store.Store.
+func (m *InMemory) PutHistogram(_ context.Context, histogram *Histogram) error {
+	m.histograms.Store(histogram.Name, histogram)
+	return nil
+}
+
+// PutScan implements store.Store.
+func (m *InMemory) PutScan(_ context.Context, scan *Scan) error {
+	m.scans.Store(scan.Name, scan)
+	return nil
+}
+
+func getNames(m *sync.Map) ([]string, error) {
+	names := make([]string, 0)
+	m.Range(func(key any, value any) bool {
+		names = append(names, key.(string))
+		return true
+	})
+	return names, nil
+}

--- a/internal/store/scan.go
+++ b/internal/store/scan.go
@@ -1,0 +1,195 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	_ "embed" // embedding sql statements
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// LogFormat defines of the log.
+type LogFormat string
+
+const (
+	// CRDBV2 is the format of the cockroach log.
+	CRDBV2 = LogFormat("crdb-v2")
+)
+
+// A Pattern defines the regular expression to match to increase the pattern counter
+type Pattern struct {
+	Help  string // Help to used to describe the pattern.
+	Name  string // Name of the pattern, which represents the property being measured.
+	Regex string // Kind is the type of the pattern.
+}
+
+// Scan defines the list of patterns that used to scan a log file.
+// This struct defines the configuration for the log.
+type Scan struct {
+	Enabled      bool             // Enabled is true if the patterns needs to be collected.
+	Format       LogFormat        // Format of the log.
+	LastModified pgtype.Timestamp // LastModified the last time the log was updated in the database.
+	Name         string           // Name of the log
+	Path         string           // Location of the log file
+	Patterns     []Pattern        // The patterns to look for
+}
+
+//go:embed sql/listScans.sql
+var listScansStmt string
+
+//go:embed sql/getScan.sql
+var getScanStmt string
+
+//go:embed sql/getPatterns.sql
+var getPatternsStmt string
+
+//go:embed sql/upsertScan.sql
+var upsertScanStmt string
+
+//go:embed sql/insertPattern.sql
+var insertPatternStmt string
+
+//go:embed sql/deleteScan.sql
+var deleteScanStmt string
+
+//go:embed sql/deletePatterns.sql
+var deletePatternsStmt string
+
+// DeleteScan removes a scan configuration and associated patterns from the database.
+func (s *store) DeleteScan(ctx context.Context, name string) error {
+	txn, err := s.conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := txn.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			log.Errorf("rollback failed %s", err)
+		}
+	}()
+	_, err = txn.Exec(ctx, deletePatternsStmt, name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = txn.Exec(ctx, deleteScanStmt, name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return txn.Commit(ctx)
+}
+
+// GetScanNames retrieves all the log names stored in the database.
+func (s *store) GetScanNames(ctx context.Context) ([]string, error) {
+	rows, err := s.conn.Query(ctx, listScansStmt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	res := make([]string, 0)
+	for rows.Next() {
+		var name string
+		err := rows.Scan(&name)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		res = append(res, name)
+	}
+	return res, nil
+}
+
+// GetScan retrieves the log configuration from the database
+func (s *store) GetScan(ctx context.Context, name string) (*Scan, error) {
+	scan := &Scan{}
+	row := s.conn.QueryRow(ctx, getScanStmt, name)
+	if err := row.Scan(&scan.Name, &scan.Path, &scan.Format,
+		&scan.LastModified, &scan.Enabled); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, errors.WithStack(err)
+	}
+	patterns, err := s.GetScanPatterns(ctx, name)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	scan.Patterns = patterns
+	return scan, nil
+}
+
+// GetScanPatterns retrieves the configuration for the patterns associated to this log.
+func (s *store) GetScanPatterns(ctx context.Context, name string) ([]Pattern, error) {
+	patterns := make([]Pattern, 0)
+	rows, err := s.conn.Query(ctx, getPatternsStmt, name)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		pattern := Pattern{}
+		err := rows.Scan(&pattern.Name, &pattern.Regex, &pattern.Help)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		patterns = append(patterns, pattern)
+	}
+	return patterns, nil
+}
+
+// PutScan adds a new log configuration to the database.
+// If a log with the same name already exists, it is replaced.
+func (s *store) PutScan(ctx context.Context, target *Scan) error {
+	log.Tracef("PutScan %+v", target)
+	txn, err := s.conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := txn.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			log.Errorf("rollback failed %s", err)
+		}
+	}()
+	_, err = txn.Exec(ctx, deletePatternsStmt, target.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = txn.Exec(ctx, upsertScanStmt,
+		target.Name, target.Path, target.Format, target.Enabled)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, pattern := range target.Patterns {
+		_, err = txn.Exec(ctx, insertPatternStmt, target.Name, pattern.Name,
+			pattern.Regex, pattern.Help)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return txn.Commit(ctx)
+}
+
+// String implements fmt.Stringer
+func (c *Scan) String() string {
+	return fmt.Sprintf(`Scan:     %s
+Enabled:  %t 
+Updated:  %s
+Format:   %s
+Path:     %s
+Patterns: %v`,
+		c.Name, c.Enabled, c.LastModified.Time, c.Path, c.Format, c.Patterns)
+}

--- a/internal/store/scan_test.go
+++ b/internal/store/scan_test.go
@@ -1,0 +1,184 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	_ "embed"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pashagolub/pgxmock/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetScanNames verifies we can get the list of scans in the database.
+func TestGetScanNames(t *testing.T) {
+	mock, err := pgxmock.NewConn()
+	require.NoError(t, err)
+	store := New(mock)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	columns := []string{"name"}
+	tests := [][]string{
+		{},
+		{"test1", "test2"},
+		{"test1", "test2", "test3"},
+	}
+	for _, tt := range tests {
+		query := mock.ExpectQuery(`select "name" from _visus.scan.+`)
+		res := mock.NewRows(columns)
+		for _, row := range tt {
+			res.AddRow(row)
+		}
+		query.WillReturnRows(res)
+		names, err := store.GetScanNames(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, names, tt)
+	}
+}
+
+// TestDeleteScan verifies we can get the delete a scan from the database.
+func TestDeleteScan(t *testing.T) {
+	mock, err := pgxmock.NewConn()
+	require.NoError(t, err)
+	store := New(mock)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	mock.ExpectBegin()
+	mock.ExpectExec("delete from _visus.pattern where scan = .+").WithArgs("test").
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectExec("delete from _visus.scan where name = .+").WithArgs("test").
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	mock.ExpectCommit()
+	err = store.DeleteScan(ctx, "test")
+	require.NoError(t, err)
+}
+
+// TestGetScan verifies we can get a scan definition from the database.
+func TestGetScan(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	type test struct {
+		name      string
+		scan      *Scan
+		wantError bool
+	}
+
+	tests := []test{
+		{"none", nil, false},
+		{"no_patterns", &Scan{
+			Enabled:      true,
+			Format:       CRDBV2,
+			Path:         "/tmp/test.log",
+			LastModified: pgtype.Timestamp{Time: time.Now()},
+			Name:         "no_patterns",
+			Patterns:     []Pattern{},
+		}, false},
+		{"with_patterns", &Scan{
+			Enabled:      true,
+			Format:       CRDBV2,
+			Path:         "/tmp/test.log",
+			LastModified: pgtype.Timestamp{Time: time.Now()},
+			Patterns: []Pattern{
+				{"cdc", "cdc", "cdc events"},
+				{"kv", "kv", "kv events"},
+			},
+			Name: "with_patterns",
+		}, false},
+	}
+	for _, tt := range tests {
+		mock, err := pgxmock.NewConn()
+		store := New(mock)
+		require.NoError(t, err)
+		collQuery := mock.ExpectQuery(`select name, path, format, updated, "enabled" from _visus.scan where name = .+`).
+			WithArgs(tt.name)
+		res := mock.NewRows([]string{"name", "path", "format", "updated", "enabled"})
+		if tt.scan != nil {
+			res.AddRow(
+				tt.name, tt.scan.Path, tt.scan.Format, tt.scan.LastModified, tt.scan.Enabled,
+			)
+		}
+		collQuery.WillReturnRows(res)
+		metricQuery := mock.ExpectQuery("select metric, regex, help from _visus.pattern where scan = .+").
+			WithArgs(tt.name)
+		res = mock.NewRows([]string{"metric", "regex", "help"})
+		if tt.scan != nil {
+			for _, row := range tt.scan.Patterns {
+				res.AddRow(row.Name, row.Regex, row.Help)
+			}
+		}
+		metricQuery.WillReturnRows(res)
+		coll, err := store.GetScan(ctx, tt.name)
+		require.NoError(t, err)
+		assert.Equal(t, tt.scan, coll)
+		mock.Close(ctx)
+	}
+}
+
+// TestPutScan verifies we can upload a scan definition to the database.
+func TestPutScan(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	type test struct {
+		name      string
+		scan      *Scan
+		wantError bool
+	}
+	tests := []test{
+		{"no_patterns", &Scan{
+			Enabled:      true,
+			Format:       CRDBV2,
+			Path:         "/tmp/test.log",
+			LastModified: pgtype.Timestamp{Time: time.Now()},
+			Name:         "no_patterns",
+			Patterns:     []Pattern{},
+		}, false},
+		{"with_patterns", &Scan{
+			Enabled:      true,
+			Format:       CRDBV2,
+			Path:         "/tmp/test.log",
+			LastModified: pgtype.Timestamp{Time: time.Now()},
+			Patterns: []Pattern{
+				{"cdc", "cdc", "cdc events"},
+				{"kv", "kv", "kv events"},
+			},
+			Name: "with_patterns",
+		}, false},
+	}
+	for _, tt := range tests {
+		mock, err := pgxmock.NewConn()
+		store := New(mock)
+		require.NoError(t, err)
+		mock.ExpectBegin()
+		mock.ExpectExec("delete from _visus.pattern where scan = .+").WithArgs(tt.scan.Name).
+			WillReturnResult(pgxmock.NewResult("DELETE", 0))
+		mock.ExpectExec(
+			`UPSERT INTO _visus.scan \(name, path, format, enabled, updated\) VALUES .+`).
+			WithArgs(tt.scan.Name, tt.scan.Path, tt.scan.Format, tt.scan.Enabled).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		for _, pattern := range tt.scan.Patterns {
+			mock.ExpectExec(`INSERT INTO _visus.pattern \(scan,metric,regex,help\) VALUES .+`).
+				WithArgs(tt.scan.Name, pattern.Name, pattern.Regex, pattern.Help).
+				WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		}
+		mock.ExpectCommit()
+		err = store.PutScan(ctx, tt.scan)
+		require.NoError(t, err)
+		mock.Close(ctx)
+	}
+}

--- a/internal/store/sql/ddl.sql
+++ b/internal/store/sql/ddl.sql
@@ -54,3 +54,24 @@ GRANT SELECT,INSERT,UPDATE ON TABLE _visus.node TO visus;
 GRANT SELECT ON TABLE _visus.collection TO visus;
 GRANT SELECT ON TABLE _visus.metric TO visus;
 GRANT SELECT ON TABLE _visus.histogram TO visus;
+
+
+CREATE TABLE IF NOT EXISTS _visus.scan (
+    name         STRING NOT NULL,
+    path         STRING NOT NULL,
+    format       STRING NOT NULL,
+    updated      timestamptz DEFAULT current_timestamp (),
+    enabled      BOOL DEFAULT true,
+    PRIMARY KEY (name)
+);
+
+CREATE TABLE IF NOT EXISTS _visus.pattern (
+    scan         STRING NOT NULL,
+    metric       STRING NOT NULL,
+    help         STRING NOT NULL,
+    regex        STRING NOT NULL,
+    PRIMARY KEY (scan, metric)
+);
+
+GRANT SELECT ON TABLE _visus.scan TO visus;
+GRANT SELECT ON TABLE _visus.pattern TO visus;

--- a/internal/store/sql/deletePatterns.sql
+++ b/internal/store/sql/deletePatterns.sql
@@ -1,0 +1,1 @@
+delete from _visus.pattern where scan = $1

--- a/internal/store/sql/deleteScan.sql
+++ b/internal/store/sql/deleteScan.sql
@@ -1,0 +1,1 @@
+delete from _visus.scan where name = $1

--- a/internal/store/sql/getPatterns.sql
+++ b/internal/store/sql/getPatterns.sql
@@ -1,0 +1,1 @@
+select metric, regex, help from _visus.pattern where scan = $1

--- a/internal/store/sql/getScan.sql
+++ b/internal/store/sql/getScan.sql
@@ -1,0 +1,1 @@
+select name, path, format, updated, "enabled" from _visus.scan where name = $1;

--- a/internal/store/sql/insertPattern.sql
+++ b/internal/store/sql/insertPattern.sql
@@ -1,0 +1,4 @@
+INSERT INTO _visus.pattern
+   (scan,metric,regex,help)
+VALUES
+   ($1,$2,$3,$4);

--- a/internal/store/sql/listScans.sql
+++ b/internal/store/sql/listScans.sql
@@ -1,0 +1,1 @@
+select "name" from _visus.scan;

--- a/internal/store/sql/upsertScan.sql
+++ b/internal/store/sql/upsertScan.sql
@@ -1,0 +1,4 @@
+UPSERT INTO _visus.scan
+   (name, path, format, enabled, updated)
+VALUES
+   ($1, $2, $3, $4, current_timestamp())

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,12 +23,14 @@ import (
 	"github.com/cockroachlabs/visus/internal/database"
 )
 
-// Store provides the CRUD function to manage collection and histogram configurations.
+// Store provides the CRUD function to manage collection, histogram and scanner configurations.
 type Store interface {
 	// DeleteCollection deletes the collection with the given name from the store.
 	DeleteCollection(ctx context.Context, name string) error
 	// DeleteHistogram deletes the histogram with the given name from the store.
 	DeleteHistogram(ctx context.Context, regex string) error
+	// DeleteScan deletes the log target with the given name from the store.
+	DeleteScan(ctx context.Context, name string) error
 	// GetCollection returns the collection with the given name.
 	GetCollection(ctx context.Context, name string) (*Collection, error)
 	// GetCollectionNames returns the collection names present in the store.
@@ -39,6 +41,12 @@ type Store interface {
 	GetHistogramNames(ctx context.Context) ([]string, error)
 	// GetMetrics returns the metrics associated to a collection.
 	GetMetrics(ctx context.Context, name string) ([]Metric, error)
+	// GetScan returns the log target with the given name.
+	GetScan(ctx context.Context, name string) (*Scan, error)
+	// GetScanNames returns the log target names present in the store.
+	GetScanNames(ctx context.Context) ([]string, error)
+	// GetScanPatterns returns the patterns associated to a log target.
+	GetScanPatterns(ctx context.Context, name string) ([]Pattern, error)
 	// Init initializes the schema in the database
 	Init(ctx context.Context) error
 	// IsMainNode returns true if the current node is the main node.
@@ -48,6 +56,8 @@ type Store interface {
 	PutCollection(ctx context.Context, collection *Collection) error
 	// PutHistogram adds a histogram configuration to the database.
 	PutHistogram(ctx context.Context, histogram *Histogram) error
+	// PutScan adds a log target configuration to the database.
+	PutScan(ctx context.Context, scan *Scan) error
 }
 
 type store struct {


### PR DESCRIPTION
This change adds the ability of scanning log messages and incrementing counters every time a log message matches a given regular expression.

The CLI has a new subcommand `scan` to manage scans, similar to the existing subcommand for collections.

The store package has been updated with the CRUD operations to manage scans.

To simplify the management of the lifecycle of the various components, we introduced the stopper.Stopper used in replicator. The code that implements the Server interface has been refactored to take advantage of it.

A in-memory version of Store has been introduced to aid in testing.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/102)
<!-- Reviewable:end -->
