### PR TITLE
stopper: refactoring server and metric collector to use the stopper utility

### DIFF
--- a/internal/metric/server_test.go
+++ b/internal/metric/server_test.go
@@ -1,0 +1,210 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/database"
+	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/go-co-op/gocron"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pashagolub/pgxmock/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dbQuery    = "SELECT database, count FROM databases LIMIT $1"
+	statsQuery = "SELECT statement, count FROM statements LIMIT $1"
+)
+
+func TestRefreshCollectors(t *testing.T) {
+	r := require.New(t)
+	a := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stop := stopper.WithContext(ctx)
+	conn := &mockDB{}
+	mockStore := &store.InMemory{}
+	mockStore.Init(ctx)
+	cfg := &server.Config{}
+	registry := prometheus.NewRegistry()
+	server := &metricsServer{
+		config:    cfg,
+		conn:      conn,
+		store:     mockStore,
+		scheduler: gocron.NewScheduler(time.UTC),
+		registry:  registry,
+	}
+	server.mu.stopped = true
+	server.mu.scheduledJobs = make(map[string]*scheduledJob)
+	server.scheduler.StartAsync()
+	// Adding a collection
+	dbTime := time.Now()
+	dbColl := &store.Collection{
+		Enabled: true,
+		Frequency: pgtype.Interval{
+			Microseconds: 1e6,
+			Valid:        true,
+		},
+		Labels: []string{"database"},
+		LastModified: pgtype.Timestamp{
+			Time:  dbTime,
+			Valid: true,
+		},
+		MaxResult: 1,
+		Metrics: []store.Metric{
+			{
+				Name: "count",
+				Kind: store.Counter,
+				Help: "num of databases",
+			},
+		},
+		Name:  "databases",
+		Query: dbQuery,
+	}
+	err := mockStore.PutCollection(ctx, dbColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok := server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+	// Modify the collection
+	dbTime = time.Now()
+	dbColl.LastModified.Time = dbTime
+	err = mockStore.PutCollection(ctx, dbColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+	// Add a new collection
+	sqlTime := time.Now()
+	sqlColl := &store.Collection{
+		Enabled: true,
+		Frequency: pgtype.Interval{
+			Microseconds: 1e6,
+			Valid:        true,
+		},
+		Labels: []string{"statement"},
+		LastModified: pgtype.Timestamp{
+			Time:  sqlTime,
+			Valid: true,
+		},
+		MaxResult: 1,
+		Metrics: []store.Metric{
+			{
+				Name: "count",
+				Kind: store.Counter,
+				Help: "num of statements",
+			},
+		},
+		Name:  "statements",
+		Query: statsQuery,
+	}
+	err = mockStore.PutCollection(ctx, sqlColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	sqlJob, ok := server.getJob(sqlColl.Name)
+	r.True(ok)
+	a.Equal(sqlJob.collector.GetLastModified(), sqlTime)
+	a.Equal(2, len(server.scheduler.Jobs()))
+	// Sleep just few seconds, make sure we see metrics
+	time.Sleep(2 * time.Second)
+	metrics, err := registry.Gather()
+	r.NoError(err)
+	a.Equal(2, len(metrics))
+	for _, m := range metrics {
+		a.Contains([]string{"databases_count", "statements_count"}, *m.Name)
+	}
+
+	// Remove the first collection
+	err = mockStore.DeleteCollection(ctx, dbColl.Name)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.False(ok)
+	a.Nil(coll)
+	sqlJob, ok = server.getJob(sqlColl.Name)
+	r.True(ok)
+	a.Equal(sqlJob.collector.GetLastModified(), sqlTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+
+}
+
+type mockDB struct {
+	dbcount, statscount atomic.Int32
+}
+
+var _ database.Connection = &mockDB{}
+
+// Begin implements database.Connection.
+func (m *mockDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	panic("unimplemented")
+}
+
+// Exec implements database.Connection.
+func (m *mockDB) Exec(
+	ctx context.Context, sql string, arguments ...interface{},
+) (pgconn.CommandTag, error) {
+	panic("unimplemented")
+}
+
+// Query implements database.Connection.
+func (m *mockDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	conn, err := pgxmock.NewConn()
+	if err != nil {
+		return nil, err
+	}
+	query := conn.ExpectQuery(strings.Replace(sql, "LIMIT $1", ".+", 1)).WithArgs(1)
+	switch sql {
+	case dbQuery:
+		m.dbcount.Add(1)
+		res := conn.NewRows([]string{"database", "count"})
+		res.AddRow("test", int(m.dbcount.Load()))
+		query.WillReturnRows(res)
+	case statsQuery:
+		m.statscount.Add(1)
+		res := conn.NewRows([]string{"statement", "count"})
+		res.AddRow("st1", int(m.statscount.Load()))
+		query.WillReturnRows(res)
+	}
+	return conn.Query(ctx, sql, args...)
+}
+
+// QueryRow implements database.Connection.
+func (m *mockDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	panic("unimplemented")
+}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -16,18 +16,18 @@ package server
 
 import "time"
 
-// Config encapsulates the command-line configurations and the logic
-// necessary to make those values usable.
+// Config encapsulates the command-line parameters that can be supplied
+// to configure the behavior of Visus.
 type Config struct {
 	BindAddr          string        // Address to bind the server to.
 	BindCert, BindKey string        // Paths to Certificate and Key.
 	CaCert            string        // Path to the Root CA.
 	Endpoint          string        // Endpoint for metrics
-	RewriteHistograms bool          // Enable histogram rewriting
 	Insecure          bool          // Sanity check to ensure that the operator really means it.
+	ProcMetrics       bool          // Enable collections of process metrics.
 	Prometheus        string        // URL for the node prometheus endpoint
 	Refresh           time.Duration // how often to refresh the configuration.
+	RewriteHistograms bool          // Enable histogram rewriting
 	URL               string        // URL to connect to the database
-	ProcMetrics       bool          // Enable collections of process metrics.
-	VisusMetrics      bool          // Enable collection of visus metrics.
+	VisusMetrics      bool          // Enable collection of Visus metrics.
 }

--- a/internal/stopper/stopper.go
+++ b/internal/stopper/stopper.go
@@ -1,0 +1,322 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stopper contains a utility class for gracefully terminating
+// long-running processes.A
+// Origin: https://github.com/cockroachdb/replicator/tree/master/internal/util/stopper
+// TODO (silvano): Move to the field engineering tools library repo.
+package stopper
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// contextKey is a [context.Context.Value] key.
+type contextKey struct{}
+
+// background is a Context that never stops.
+var background = &Context{
+	delegate: context.Background(),
+	stopping: make(chan struct{}),
+}
+
+// ErrStopped will be returned from [context.Cause] when the Context has
+// been stopped.
+var ErrStopped = errors.New("stopped")
+
+// ErrGracePeriodExpired will be returned from [context.Cause] when the
+// Context has been stopped, but the goroutines have not exited.
+var ErrGracePeriodExpired = errors.New("grace period expired")
+
+// A Context is conceptually similar to an [errgroup.Group] in that it
+// manages a [context.Context] whose lifecycle is associated with some
+// number of goroutines. Rather than canceling the associated context
+// when a goroutine returns an error, it cancels the context after the
+// Stop method is called and all associated goroutines have all exited.
+//
+// As an API convenience, the Context type implements [context.Context]
+// so that it fits into idiomatic context-plumbing.  The [From]
+// function can be used to retrieve a Context from any
+// [context.Context].
+type Context struct {
+	cancel   func(error) // Invoked via cancelLocked.
+	delegate context.Context
+	stopping chan struct{}
+	parent   *Context
+
+	mu struct {
+		sync.RWMutex
+		count    int
+		deferred []func()
+		err      error
+		stopping bool
+	}
+}
+
+var _ context.Context = (*Context)(nil)
+
+// Background is analogous to [context.Background]. It returns a Context
+// which cannot be stopped or canceled, but which is otherwise
+// functional.
+func Background() *Context { return background }
+
+// From returns a pre-existing Context from the Context chain. Use
+// [WithContext] to construct a new Context.
+//
+// If the chain is not associated with a Context, the [Background]
+// instance will be returned.
+func From(ctx context.Context) *Context {
+	if s, ok := ctx.(*Context); ok {
+		return s
+	}
+	if s := ctx.Value(contextKey{}); s != nil {
+		return s.(*Context)
+	}
+	return Background()
+}
+
+// IsStopping is a convenience method to determine if a stopper is
+// associated with a Context and if work should be stopped.
+func IsStopping(ctx context.Context) bool {
+	return From(ctx).IsStopping()
+}
+
+// WithContext creates a new Context whose work will be immediately
+// canceled when the parent context is canceled. If the provided context
+// is already managed by a Context, a call to the enclosing
+// [Context.Stop] method will also trigger a call to Stop in the
+// newly-constructed Context.
+func WithContext(ctx context.Context) *Context {
+	// Might be background, which never stops.
+	parent := From(ctx)
+
+	ctx, cancel := context.WithCancelCause(ctx)
+	s := &Context{
+		cancel:   cancel,
+		delegate: ctx,
+		parent:   parent,
+		stopping: make(chan struct{}),
+	}
+
+	// Propagate a parent stop or context cancellation into a Stop call
+	// to ensure that all notification channels are closed.
+	go func() {
+		select {
+		case <-parent.Stopping():
+		case <-s.Done():
+		}
+		s.Stop(0)
+	}()
+	return s
+}
+
+// Deadline implements [context.Context].
+func (s *Context) Deadline() (deadline time.Time, ok bool) { return s.delegate.Deadline() }
+
+// Defer registers a callback that will be executed after the
+// [Context.Done] channel is closed. This method can be used to clean up
+// resources that are used by goroutines associated with the Context
+// (e.g. closing database connections). The Context will already have
+// been canceled by the time the callback is run, so its behaviors
+// should be associated with a background context. Callbacks will be
+// executed in a LIFO manner. If the context has already stopped, the
+// callback will be executed immediately.
+//
+// Calling this method on the Background context will panic, since that
+// context can never be cancelled.
+func (s *Context) Defer(fn func()) {
+	if s == background {
+		panic(errors.New("cannot call Context.Defer() on a background context"))
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Err() != nil {
+		fn()
+		return
+	}
+	s.mu.deferred = append(s.mu.deferred, fn)
+}
+
+// Done implements [context.Context]. The channel that is returned will
+// be closed when Stop has been called and all associated goroutines
+// have exited. The returned channel will be closed immediately if the
+// parent context (passed to [WithContext]) is canceled. Functions
+// passed to [Context.Go] should prefer [Context.Stopping] instead.
+func (s *Context) Done() <-chan struct{} { return s.delegate.Done() }
+
+// Err implements context.Context. When the return value for this is
+// [context.ErrCanceled], [context.Cause] will return [ErrStopped] if
+// the context cancellation resulted from a call to Stop.
+func (s *Context) Err() error { return s.delegate.Err() }
+
+// Go spawns a new goroutine to execute the given function and monitors
+// its lifecycle.
+//
+// If the function returns an error, the Stop method will be called. The
+// returned error will be available from Wait once the remaining
+// goroutines have exited.
+//
+// This method will not execute the function and return false if Stop
+// has already been called.
+//
+// The function passed to Go should prefer the [Context.Stopping]
+// channel to return instead of depending on [Context.Done]. This allows
+// a soft-stop, rather than waiting for the grace period to expire when
+// [Context.Stop] is called.
+func (s *Context) Go(fn func() error) (accepted bool) {
+	if !s.apply(1) {
+		return false
+	}
+
+	go func() {
+		defer s.apply(-1)
+		if err := fn(); err != nil {
+			s.Stop(0)
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			if s.mu.err == nil {
+				s.mu.err = err
+			}
+		}
+	}()
+	return true
+}
+
+// IsStopping returns true once [Stop] has been called.  See also
+// [Stopping] for a notification-based API.
+func (s *Context) IsStopping() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.stopping
+}
+
+// Stop begins a graceful shutdown of the Context. When this method is
+// called, the Stopping channel will be closed.  Once all goroutines
+// started by Go have exited, the associated Context will be cancelled,
+// thus closing the Done channel. If the gracePeriod is non-zero, the
+// context will be forcefully cancelled if the goroutines have not
+// exited within the given timeframe.
+func (s *Context) Stop(gracePeriod time.Duration) {
+	if s == background {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.mu.stopping {
+		return
+	}
+	s.mu.stopping = true
+	close(s.stopping)
+
+	// Cancel the context if nothing's currently running.
+	if s.mu.count == 0 {
+		s.cancelLocked(ErrStopped)
+	} else if gracePeriod > 0 {
+		go func() {
+			select {
+			case <-time.After(gracePeriod):
+				// Cancel after the grace period has expired. This
+				// should immediately terminate any well-behaved
+				// goroutines driven by Go().
+				s.mu.Lock()
+				defer s.mu.Unlock()
+				s.cancelLocked(ErrGracePeriodExpired)
+			case <-s.Done():
+				// We'll hit this path in a clean-exit, where apply()
+				// cancels the context after the last goroutine has
+				// exited.
+			}
+		}()
+	}
+}
+
+// Stopping returns a channel that is closed when a graceful shutdown
+// has been requested or when the parent context has been canceled.
+func (s *Context) Stopping() <-chan struct{} {
+	return s.stopping
+}
+
+// Value implements context.Context.
+func (s *Context) Value(key any) any {
+	if _, ok := key.(contextKey); ok {
+		return s
+	}
+	return s.delegate.Value(key)
+}
+
+// Wait will block until Stop has been called and all associated
+// goroutines have exited or the parent context has been cancelled. This
+// method will return the first, non-nil error from any of the callbacks
+// passed to Go. If Wait is called on the [Background] instance, it will
+// immediately return nil.
+func (s *Context) Wait() error {
+	if s == background {
+		return nil
+	}
+	<-s.Done()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.err
+}
+
+// apply is used to maintain the count of started goroutines. It returns
+// true if the delta was applied.
+func (s *Context) apply(delta int) bool {
+	if s == background {
+		return true
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Don't allow new goroutines to be added when stopping.
+	if s.mu.stopping && delta >= 0 {
+		return false
+	}
+
+	// Ensure that nested jobs prolong the lifetime of the parent
+	// context to prevent premature cancellation. Verify that the parent
+	// accepted the delta in case it was just stopped, but our helper
+	// goroutine hasn't yet called Stop on this instance.
+	if !s.parent.apply(delta) {
+		return false
+	}
+
+	s.mu.count += delta
+	if s.mu.count < 0 {
+		// Implementation error, not user problem.
+		panic("over-released")
+	}
+	if s.mu.count == 0 && s.mu.stopping {
+		s.cancelLocked(ErrStopped)
+	}
+	return true
+}
+
+// cancelLocked invokes the context-cancellation function and then
+// executes any deferred callbacks.
+func (s *Context) cancelLocked(err error) {
+	s.cancel(err)
+	for i := len(s.mu.deferred) - 1; i >= 0; i-- {
+		s.mu.deferred[i]()
+	}
+	s.mu.deferred = nil
+}

--- a/internal/stopper/stopper_test.go
+++ b/internal/stopper/stopper_test.go
@@ -1,0 +1,247 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stopper
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAmbient(t *testing.T) {
+	a := assert.New(t)
+
+	s := From(context.Background())
+	a.Same(s, background)
+
+	a.False(IsStopping(context.Background()))
+	s.Go(func() error { return nil })
+
+	// Should be a no-op.
+	s.Stop(0)
+	a.False(s.mu.stopping)
+	a.Nil(s.Err())
+	a.Nil(s.Wait())
+}
+
+func TestCancelOuter(t *testing.T) {
+	a := assert.New(t)
+
+	top, cancelTop := context.WithCancel(context.Background())
+
+	s := WithContext(top)
+
+	s.Go(func() error { <-s.Done(); return nil })
+
+	cancelTop()
+	select {
+	case <-s.Stopping():
+	// Verify that canceling the top-level also closes the Stopping channel.
+	case <-time.After(time.Second):
+		a.Fail("timed out waiting for Stopping to close")
+	}
+	a.True(IsStopping(s))
+	a.ErrorIs(s.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(s), context.Canceled)
+	a.Nil(s.Wait())
+}
+
+func TestCallbackErrorStops(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	err := errors.New("BOOM")
+	s.Go(func() error { return err })
+	a.ErrorIs(s.Wait(), err)
+	a.Error(context.Cause(s), ErrStopped)
+}
+
+func TestChainStopper(t *testing.T) {
+	a := assert.New(t)
+
+	parent := WithContext(context.Background())
+	mid := context.WithValue(parent, parent, parent) // Demonstrate unwrapping.
+	child := WithContext(mid)
+	a.Same(parent, child.parent)
+
+	waitFor := make(chan struct{})
+	child.Go(func() error { <-waitFor; return nil })
+
+	// Verify that stopping the parent propagates to the child.
+	parent.Stop(0)
+	select {
+	case <-child.Stopping():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("call to stop did not propagate")
+	}
+
+	// However, the contexts should not cancel until the work is done.
+	a.Nil(parent.Err())
+	a.Nil(child.Err())
+
+	// Allow the work to finish, and verify cancellation.
+	close(waitFor)
+
+	select {
+	case <-child.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for child to finish")
+	}
+
+	select {
+	case <-mid.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for mid to finish")
+	}
+
+	select {
+	case <-parent.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for parent to finish")
+	}
+
+	a.ErrorIs(child.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(child), ErrStopped)
+	a.Nil(child.Wait())
+
+	a.ErrorIs(mid.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(mid), ErrStopped)
+
+	a.ErrorIs(parent.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(parent), ErrStopped)
+	a.Nil(child.Wait())
+}
+
+func TestDefer(t *testing.T) {
+	a := assert.New(t)
+
+	var mu sync.Mutex
+	var calls []string
+	recordCall := func(s string) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, s)
+	}
+
+	s := WithContext(context.Background())
+	s.Defer(func() { recordCall("fifo_a") })
+	s.Defer(func() { recordCall("fifo_b") })
+	s.Go(func() error {
+		recordCall("fifo_c")
+		s.Stop(time.Second)
+		return nil
+	})
+	a.Nil(s.Wait())
+	s.Defer(func() { recordCall("immediate_a") })
+	s.Defer(func() { recordCall("immediate_b") })
+
+	mu.Lock()
+	defer mu.Unlock()
+	a.Equal([]string{"fifo_c", "fifo_b", "fifo_a", "immediate_a", "immediate_b"}, calls)
+
+	a.PanicsWithError("cannot call Context.Defer() on a background context", func() {
+		Background().Defer(func() {})
+	})
+}
+
+func TestGracePeriod(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+
+	// This goroutine waits on Done, which is not correct.
+	s.Go(func() error { <-s.Done(); return nil })
+
+	s.Stop(time.Nanosecond)
+
+	<-s.Done()
+	a.ErrorIs(s.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(s), ErrGracePeriodExpired)
+}
+
+func TestStopper(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	a.Same(s, From(s))                          // Direct cast
+	a.Same(s, From(context.WithValue(s, s, s))) // Unwrapping
+	select {
+	case <-s.Stopping():
+		a.Fail("should not be stopping yet")
+	default:
+		// OK
+	}
+	a.False(IsStopping(s))
+
+	waitFor := make(chan struct{})
+	a.True(s.Go(func() error { <-waitFor; return nil }))
+	a.True(s.Go(func() error { return nil }))
+
+	s.Stop(0)
+	select {
+	case <-s.Stopping():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for stopped")
+	}
+
+	// Verify that the context is stopping, but not cancelled.
+	a.True(IsStopping(s))
+	a.Nil(s.Err())
+
+	// It's a no-op to run new routines after stopping.
+	a.False(s.Go(func() error { return nil }))
+
+	// Stop the waiting goroutines.
+	close(waitFor)
+
+	// Once all workers have stopped, the context should cancel.
+	select {
+	case <-s.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for Context.Done()")
+	}
+	a.True(IsStopping(s))
+	a.NotNil(s.Err())
+	a.ErrorIs(context.Cause(s), ErrStopped)
+	a.Nil(s.Wait())
+}
+
+// Verify that a never-used Stopper behaves correctly.
+func TestUnused(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	s.Stop(0)
+	select {
+	case <-s.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for Context.Done()")
+	}
+	a.ErrorIs(context.Cause(s), ErrStopped)
+	a.Nil(s.Wait())
+}

--- a/internal/store/histogram.go
+++ b/internal/store/histogram.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	_ "embed" // embedding sql statements
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	log "github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 )
 
 // Histogram stores the properties for a histogram definition.
@@ -49,59 +50,38 @@ var deleteHistogramStmt string
 
 // DeleteHistogram removes a histogram configuration from the database.
 func (s *store) DeleteHistogram(ctx context.Context, regex string) error {
-	txn, err := s.conn.Begin(ctx)
-	if err != nil {
-		log.Debugln(err)
-		return err
-	}
-	defer txn.Commit(ctx)
-	_, err = txn.Exec(ctx, deleteHistogramStmt, regex)
-	if err != nil {
-		log.Errorf("delete histogram error:%s", err)
-		txn.Rollback(ctx)
-		return err
-	}
-	return nil
+	_, err := s.conn.Exec(ctx, deleteHistogramStmt, regex)
+	return err
 }
 
 // GetHistograms retrieves all the histograms stored in the database.
 func (s *store) GetHistogram(ctx context.Context, name string) (*Histogram, error) {
-	rows, err := s.conn.Query(ctx, getHistogramStmt, name)
-	if err != nil {
-		log.Errorf("GetHistogram %s ", err.Error())
-		return nil, err
-	}
-	defer rows.Close()
-	if rows.Next() {
-		histogram := &Histogram{}
-		err := rows.Scan(
-			&histogram.Name, &histogram.Regex,
-			&histogram.LastModified, &histogram.Enabled,
-			&histogram.Bins, &histogram.Start, &histogram.End)
-		if err != nil {
-			log.Debugln(err)
-			return nil, err
+	row := s.conn.QueryRow(ctx, getHistogramStmt, name)
+	histogram := &Histogram{}
+	if err := row.Scan(
+		&histogram.Name, &histogram.Regex,
+		&histogram.LastModified, &histogram.Enabled,
+		&histogram.Bins, &histogram.Start, &histogram.End); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
 		}
-		return histogram, nil
+		return nil, errors.WithStack(err)
 	}
-	return nil, err
+	return histogram, nil
 }
 
 // GetHistograms retrieves all the histograms stored in the database.
 func (s *store) GetHistogramNames(ctx context.Context) ([]string, error) {
 	rows, err := s.conn.Query(ctx, listHistogramsStmt)
 	if err != nil {
-		log.Errorf("GetHistogramNames %s ", err.Error())
 		return nil, err
 	}
 	defer rows.Close()
 	res := make([]string, 0)
-
 	for rows.Next() {
 		var name string
 		err := rows.Scan(&name)
 		if err != nil {
-			log.Debugln(err)
 			return nil, err
 		}
 		res = append(res, name)
@@ -112,21 +92,9 @@ func (s *store) GetHistogramNames(ctx context.Context) ([]string, error) {
 // PutHistogram adds a new histogram configuration to the database.
 // If a histogram with the same regex already exists, it is replaced.
 func (s *store) PutHistogram(ctx context.Context, histogram *Histogram) error {
-	log.Debugf("%+v", histogram)
-	txn, err := s.conn.Begin(ctx)
-	if err != nil {
-		log.Debugln(err)
-		return err
-	}
-	defer txn.Commit(ctx)
-	_, err = txn.Exec(ctx, upsertHistogramStmt,
+	_, err := s.conn.Exec(ctx, upsertHistogramStmt,
 		histogram.Name,
 		histogram.Regex, histogram.Bins,
 		histogram.Start, histogram.End)
-	if err != nil {
-		log.Errorf("upsert histogram error:%s, %s", upsertHistogramStmt, err)
-		txn.Rollback(ctx)
-		return err
-	}
-	return nil
+	return err
 }

--- a/internal/store/inmemory.go
+++ b/internal/store/inmemory.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// InMemory stores the configuration in memory. Used for testing.
+type InMemory struct {
+	MainNode    bool
+	collections *sync.Map
+	histograms  *sync.Map
+}
+
+var _ Store = &InMemory{}
+
+// DeleteCollection implements store.Store.
+func (m *InMemory) DeleteCollection(_ context.Context, name string) error {
+	m.collections.Delete(name)
+	return nil
+}
+
+// DeleteHistogram implements store.Store.
+func (m *InMemory) DeleteHistogram(_ context.Context, name string) error {
+	m.histograms.Delete(name)
+	return nil
+}
+
+// GetCollection implements store.Store.
+func (m *InMemory) GetCollection(_ context.Context, name string) (*Collection, error) {
+	res, _ := m.collections.Load(name)
+	return res.(*Collection), nil
+}
+
+// GetCollectionNames implements store.Store.
+func (m *InMemory) GetCollectionNames(_ context.Context) ([]string, error) {
+	return getNames(m.collections)
+}
+
+// GetHistogram implements store.Store.
+func (m *InMemory) GetHistogram(_ context.Context, name string) (*Histogram, error) {
+	res, _ := m.histograms.Load(name)
+	return res.(*Histogram), nil
+}
+
+// GetHistogramNames implements store.Store.
+func (m *InMemory) GetHistogramNames(_ context.Context) ([]string, error) {
+	return getNames(m.histograms)
+}
+
+// GetMetrics implements store.Store.
+func (m *InMemory) GetMetrics(ctx context.Context, name string) ([]Metric, error) {
+	coll, _ := m.GetCollection(ctx, name)
+	return coll.Metrics, nil
+}
+
+// Init implements store.Store.
+func (m *InMemory) Init(_ context.Context) error {
+	m.collections = &sync.Map{}
+	m.histograms = &sync.Map{}
+	return nil
+}
+
+// IsMainNode implements store.Store.
+func (m *InMemory) IsMainNode(_ context.Context, lastUpdated time.Time) (bool, error) {
+	return m.MainNode, nil
+}
+
+// PutCollection implements store.Store.
+func (m *InMemory) PutCollection(_ context.Context, collection *Collection) error {
+	m.collections.Store(collection.Name, collection)
+	return nil
+}
+
+// PutHistogram implements store.Store.
+func (m *InMemory) PutHistogram(_ context.Context, histogram *Histogram) error {
+	m.histograms.Store(histogram.Name, histogram)
+	return nil
+}
+
+func getNames(m *sync.Map) ([]string, error) {
+	names := make([]string, 0)
+	m.Range(func(key any, value any) bool {
+		names = append(names, key.(string))
+		return true
+	})
+	return names, nil
+}


### PR DESCRIPTION
To simplify the management of the lifecycle of the various components, we are using the stopper.Stopper utility
taken from https://github.com/cockroachdb/replicator
The code that implements the Server interface has been refactored to take advantage of it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/112)
<!-- Reviewable:end -->
