### PR TITLE
store: adding support for scans.

### DIFF
--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -25,6 +25,7 @@ type Memory struct {
 	MainNode    bool
 	collections *sync.Map
 	histograms  *sync.Map
+	scans       *sync.Map
 }
 
 var _ Store = &Memory{}
@@ -38,6 +39,12 @@ func (m *Memory) DeleteCollection(_ context.Context, name string) error {
 // DeleteHistogram implements store.Store.
 func (m *Memory) DeleteHistogram(_ context.Context, name string) error {
 	m.histograms.Delete(name)
+	return nil
+}
+
+// DeleteScan implements store.Store.
+func (m *Memory) DeleteScan(_ context.Context, name string) error {
+	m.scans.Delete(name)
 	return nil
 }
 
@@ -69,10 +76,28 @@ func (m *Memory) GetMetrics(ctx context.Context, name string) ([]Metric, error) 
 	return coll.Metrics, nil
 }
 
+// GetScan implements store.Store.
+func (m *Memory) GetScan(_ context.Context, name string) (*Scan, error) {
+	res, _ := m.scans.Load(name)
+	return res.(*Scan), nil
+}
+
+// GetScanNames implements store.Store.
+func (m *Memory) GetScanNames(_ context.Context) ([]string, error) {
+	return getNames(m.scans)
+}
+
+// GetScanPatterns implements store.Store.
+func (m *Memory) GetScanPatterns(ctx context.Context, name string) ([]Pattern, error) {
+	scan, _ := m.GetScan(ctx, name)
+	return scan.Patterns, nil
+}
+
 // Init implements store.Store.
 func (m *Memory) Init(_ context.Context) error {
 	m.collections = &sync.Map{}
 	m.histograms = &sync.Map{}
+	m.scans = &sync.Map{}
 	return nil
 }
 
@@ -90,6 +115,12 @@ func (m *Memory) PutCollection(_ context.Context, collection *Collection) error 
 // PutHistogram implements store.Store.
 func (m *Memory) PutHistogram(_ context.Context, histogram *Histogram) error {
 	m.histograms.Store(histogram.Name, histogram)
+	return nil
+}
+
+// PutScan implements store.Store.
+func (m *Memory) PutScan(_ context.Context, scan *Scan) error {
+	m.scans.Store(scan.Name, scan)
 	return nil
 }
 

--- a/internal/store/scan.go
+++ b/internal/store/scan.go
@@ -1,0 +1,195 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	_ "embed" // embedding sql statements
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// LogFormat defines of the log.
+type LogFormat string
+
+const (
+	// CRDBV2 is the format of the cockroach log.
+	CRDBV2 = LogFormat("crdb-v2")
+)
+
+// A Pattern defines the regular expression to match to increase the pattern counter
+type Pattern struct {
+	Help  string // Help to used to describe the pattern.
+	Name  string // Name of the pattern, which represents the property being measured.
+	Regex string // Kind is the type of the pattern.
+}
+
+// Scan defines the list of patterns that used to scan a log file.
+// This struct defines the configuration for the log.
+type Scan struct {
+	Enabled      bool             // Enabled is true if the patterns needs to be collected.
+	Format       LogFormat        // Format of the log.
+	LastModified pgtype.Timestamp // LastModified the last time the log was updated in the database.
+	Name         string           // Name of the log
+	Path         string           // Location of the log file
+	Patterns     []Pattern        // The patterns to look for
+}
+
+//go:embed sql/listScans.sql
+var listScansStmt string
+
+//go:embed sql/getScan.sql
+var getScanStmt string
+
+//go:embed sql/getPatterns.sql
+var getPatternsStmt string
+
+//go:embed sql/upsertScan.sql
+var upsertScanStmt string
+
+//go:embed sql/insertPattern.sql
+var insertPatternStmt string
+
+//go:embed sql/deleteScan.sql
+var deleteScanStmt string
+
+//go:embed sql/deletePatterns.sql
+var deletePatternsStmt string
+
+// DeleteScan removes a scan configuration and associated patterns from the database.
+func (s *store) DeleteScan(ctx context.Context, name string) error {
+	txn, err := s.conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := txn.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			log.Errorf("rollback failed %s", err)
+		}
+	}()
+	_, err = txn.Exec(ctx, deletePatternsStmt, name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = txn.Exec(ctx, deleteScanStmt, name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return txn.Commit(ctx)
+}
+
+// GetScanNames retrieves all the log names stored in the database.
+func (s *store) GetScanNames(ctx context.Context) ([]string, error) {
+	rows, err := s.conn.Query(ctx, listScansStmt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	res := make([]string, 0)
+	for rows.Next() {
+		var name string
+		err := rows.Scan(&name)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		res = append(res, name)
+	}
+	return res, nil
+}
+
+// GetScan retrieves the log configuration from the database
+func (s *store) GetScan(ctx context.Context, name string) (*Scan, error) {
+	scan := &Scan{}
+	row := s.conn.QueryRow(ctx, getScanStmt, name)
+	if err := row.Scan(&scan.Name, &scan.Path, &scan.Format,
+		&scan.LastModified, &scan.Enabled); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, errors.WithStack(err)
+	}
+	patterns, err := s.GetScanPatterns(ctx, name)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	scan.Patterns = patterns
+	return scan, nil
+}
+
+// GetScanPatterns retrieves the configuration for the patterns associated to this log.
+func (s *store) GetScanPatterns(ctx context.Context, name string) ([]Pattern, error) {
+	patterns := make([]Pattern, 0)
+	rows, err := s.conn.Query(ctx, getPatternsStmt, name)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		pattern := Pattern{}
+		err := rows.Scan(&pattern.Name, &pattern.Regex, &pattern.Help)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		patterns = append(patterns, pattern)
+	}
+	return patterns, nil
+}
+
+// PutScan adds a new log configuration to the database.
+// If a log with the same name already exists, it is replaced.
+func (s *store) PutScan(ctx context.Context, target *Scan) error {
+	log.Tracef("PutScan %+v", target)
+	txn, err := s.conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := txn.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			log.Errorf("rollback failed %s", err)
+		}
+	}()
+	_, err = txn.Exec(ctx, deletePatternsStmt, target.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = txn.Exec(ctx, upsertScanStmt,
+		target.Name, target.Path, target.Format, target.Enabled)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, pattern := range target.Patterns {
+		_, err = txn.Exec(ctx, insertPatternStmt, target.Name, pattern.Name,
+			pattern.Regex, pattern.Help)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return txn.Commit(ctx)
+}
+
+// String implements fmt.Stringer
+func (c *Scan) String() string {
+	return fmt.Sprintf(`Scan:     %s
+Enabled:  %t
+Updated:  %s
+Format:   %s
+Path:     %s
+Patterns: %v`,
+		c.Name, c.Enabled, c.LastModified.Time, c.Path, c.Format, c.Patterns)
+}

--- a/internal/store/scan_test.go
+++ b/internal/store/scan_test.go
@@ -1,0 +1,184 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	_ "embed"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pashagolub/pgxmock/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetScanNames verifies we can get the list of scans in the database.
+func TestGetScanNames(t *testing.T) {
+	mock, err := pgxmock.NewConn()
+	require.NoError(t, err)
+	store := New(mock)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	columns := []string{"name"}
+	tests := [][]string{
+		{},
+		{"test1", "test2"},
+		{"test1", "test2", "test3"},
+	}
+	for _, tt := range tests {
+		query := mock.ExpectQuery(`select "name" from _visus.scan.+`)
+		res := mock.NewRows(columns)
+		for _, row := range tt {
+			res.AddRow(row)
+		}
+		query.WillReturnRows(res)
+		names, err := store.GetScanNames(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, names, tt)
+	}
+}
+
+// TestDeleteScan verifies we can get the delete a scan from the database.
+func TestDeleteScan(t *testing.T) {
+	mock, err := pgxmock.NewConn()
+	require.NoError(t, err)
+	store := New(mock)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	mock.ExpectBegin()
+	mock.ExpectExec("delete from _visus.pattern where scan = .+").WithArgs("test").
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectExec("delete from _visus.scan where name = .+").WithArgs("test").
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	mock.ExpectCommit()
+	err = store.DeleteScan(ctx, "test")
+	require.NoError(t, err)
+}
+
+// TestGetScan verifies we can get a scan definition from the database.
+func TestGetScan(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	type test struct {
+		name      string
+		scan      *Scan
+		wantError bool
+	}
+
+	tests := []test{
+		{"none", nil, false},
+		{"no_patterns", &Scan{
+			Enabled:      true,
+			Format:       CRDBV2,
+			Path:         "/tmp/test.log",
+			LastModified: pgtype.Timestamp{Time: time.Now()},
+			Name:         "no_patterns",
+			Patterns:     []Pattern{},
+		}, false},
+		{"with_patterns", &Scan{
+			Enabled:      true,
+			Format:       CRDBV2,
+			Path:         "/tmp/test.log",
+			LastModified: pgtype.Timestamp{Time: time.Now()},
+			Patterns: []Pattern{
+				{"cdc", "cdc", "cdc events"},
+				{"kv", "kv", "kv events"},
+			},
+			Name: "with_patterns",
+		}, false},
+	}
+	for _, tt := range tests {
+		mock, err := pgxmock.NewConn()
+		store := New(mock)
+		require.NoError(t, err)
+		collQuery := mock.ExpectQuery(`select name, path, format, updated, "enabled" from _visus.scan where name = .+`).
+			WithArgs(tt.name)
+		res := mock.NewRows([]string{"name", "path", "format", "updated", "enabled"})
+		if tt.scan != nil {
+			res.AddRow(
+				tt.name, tt.scan.Path, tt.scan.Format, tt.scan.LastModified, tt.scan.Enabled,
+			)
+		}
+		collQuery.WillReturnRows(res)
+		metricQuery := mock.ExpectQuery("select metric, regex, help from _visus.pattern where scan = .+").
+			WithArgs(tt.name)
+		res = mock.NewRows([]string{"metric", "regex", "help"})
+		if tt.scan != nil {
+			for _, row := range tt.scan.Patterns {
+				res.AddRow(row.Name, row.Regex, row.Help)
+			}
+		}
+		metricQuery.WillReturnRows(res)
+		coll, err := store.GetScan(ctx, tt.name)
+		require.NoError(t, err)
+		assert.Equal(t, tt.scan, coll)
+		mock.Close(ctx)
+	}
+}
+
+// TestPutScan verifies we can upload a scan definition to the database.
+func TestPutScan(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	type test struct {
+		name      string
+		scan      *Scan
+		wantError bool
+	}
+	tests := []test{
+		{"no_patterns", &Scan{
+			Enabled:      true,
+			Format:       CRDBV2,
+			Path:         "/tmp/test.log",
+			LastModified: pgtype.Timestamp{Time: time.Now()},
+			Name:         "no_patterns",
+			Patterns:     []Pattern{},
+		}, false},
+		{"with_patterns", &Scan{
+			Enabled:      true,
+			Format:       CRDBV2,
+			Path:         "/tmp/test.log",
+			LastModified: pgtype.Timestamp{Time: time.Now()},
+			Patterns: []Pattern{
+				{"cdc", "cdc", "cdc events"},
+				{"kv", "kv", "kv events"},
+			},
+			Name: "with_patterns",
+		}, false},
+	}
+	for _, tt := range tests {
+		mock, err := pgxmock.NewConn()
+		store := New(mock)
+		require.NoError(t, err)
+		mock.ExpectBegin()
+		mock.ExpectExec("delete from _visus.pattern where scan = .+").WithArgs(tt.scan.Name).
+			WillReturnResult(pgxmock.NewResult("DELETE", 0))
+		mock.ExpectExec(
+			`UPSERT INTO _visus.scan \(name, path, format, enabled, updated\) VALUES .+`).
+			WithArgs(tt.scan.Name, tt.scan.Path, tt.scan.Format, tt.scan.Enabled).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		for _, pattern := range tt.scan.Patterns {
+			mock.ExpectExec(`INSERT INTO _visus.pattern \(scan,metric,regex,help\) VALUES .+`).
+				WithArgs(tt.scan.Name, pattern.Name, pattern.Regex, pattern.Help).
+				WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		}
+		mock.ExpectCommit()
+		err = store.PutScan(ctx, tt.scan)
+		require.NoError(t, err)
+		mock.Close(ctx)
+	}
+}

--- a/internal/store/sql/ddl.sql
+++ b/internal/store/sql/ddl.sql
@@ -54,3 +54,24 @@ GRANT SELECT,INSERT,UPDATE ON TABLE _visus.node TO visus;
 GRANT SELECT ON TABLE _visus.collection TO visus;
 GRANT SELECT ON TABLE _visus.metric TO visus;
 GRANT SELECT ON TABLE _visus.histogram TO visus;
+
+
+CREATE TABLE IF NOT EXISTS _visus.scan (
+    name         STRING NOT NULL,
+    path         STRING NOT NULL,
+    format       STRING NOT NULL,
+    updated      timestamptz DEFAULT current_timestamp (),
+    enabled      BOOL DEFAULT true,
+    PRIMARY KEY (name)
+);
+
+CREATE TABLE IF NOT EXISTS _visus.pattern (
+    scan         STRING NOT NULL,
+    metric       STRING NOT NULL,
+    help         STRING NOT NULL,
+    regex        STRING NOT NULL,
+    PRIMARY KEY (scan, metric)
+);
+
+GRANT SELECT ON TABLE _visus.scan TO visus;
+GRANT SELECT ON TABLE _visus.pattern TO visus;

--- a/internal/store/sql/deletePatterns.sql
+++ b/internal/store/sql/deletePatterns.sql
@@ -1,0 +1,1 @@
+delete from _visus.pattern where scan = $1

--- a/internal/store/sql/deleteScan.sql
+++ b/internal/store/sql/deleteScan.sql
@@ -1,0 +1,1 @@
+delete from _visus.scan where name = $1

--- a/internal/store/sql/getPatterns.sql
+++ b/internal/store/sql/getPatterns.sql
@@ -1,0 +1,1 @@
+select metric, regex, help from _visus.pattern where scan = $1

--- a/internal/store/sql/getScan.sql
+++ b/internal/store/sql/getScan.sql
@@ -1,0 +1,1 @@
+select name, path, format, updated, "enabled" from _visus.scan where name = $1;

--- a/internal/store/sql/insertPattern.sql
+++ b/internal/store/sql/insertPattern.sql
@@ -1,0 +1,4 @@
+INSERT INTO _visus.pattern
+   (scan,metric,regex,help)
+VALUES
+   ($1,$2,$3,$4);

--- a/internal/store/sql/listScans.sql
+++ b/internal/store/sql/listScans.sql
@@ -1,0 +1,1 @@
+select "name" from _visus.scan;

--- a/internal/store/sql/upsertScan.sql
+++ b/internal/store/sql/upsertScan.sql
@@ -1,0 +1,4 @@
+UPSERT INTO _visus.scan
+   (name, path, format, enabled, updated)
+VALUES
+   ($1, $2, $3, $4, current_timestamp())

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,12 +23,14 @@ import (
 	"github.com/cockroachlabs/visus/internal/database"
 )
 
-// Store provides the CRUD function to manage collection and histogram configurations.
+// Store provides the CRUD function to manage collection, histogram and scanner configurations.
 type Store interface {
 	// DeleteCollection deletes the collection with the given name from the store.
 	DeleteCollection(ctx context.Context, name string) error
 	// DeleteHistogram deletes the histogram with the given name from the store.
 	DeleteHistogram(ctx context.Context, regex string) error
+	// DeleteScan deletes the log target with the given name from the store.
+	DeleteScan(ctx context.Context, name string) error
 	// GetCollection returns the collection with the given name.
 	GetCollection(ctx context.Context, name string) (*Collection, error)
 	// GetCollectionNames returns the collection names present in the store.
@@ -39,6 +41,12 @@ type Store interface {
 	GetHistogramNames(ctx context.Context) ([]string, error)
 	// GetMetrics returns the metrics associated to a collection.
 	GetMetrics(ctx context.Context, name string) ([]Metric, error)
+	// GetScan returns the log target with the given name.
+	GetScan(ctx context.Context, name string) (*Scan, error)
+	// GetScanNames returns the log target names present in the store.
+	GetScanNames(ctx context.Context) ([]string, error)
+	// GetScanPatterns returns the patterns associated to a log target.
+	GetScanPatterns(ctx context.Context, name string) ([]Pattern, error)
 	// Init initializes the schema in the database
 	Init(ctx context.Context) error
 	// IsMainNode returns true if the current node is the main node.
@@ -48,6 +56,8 @@ type Store interface {
 	PutCollection(ctx context.Context, collection *Collection) error
 	// PutHistogram adds a histogram configuration to the database.
 	PutHistogram(ctx context.Context, histogram *Histogram) error
+	// PutScan adds a log target configuration to the database.
+	PutScan(ctx context.Context, scan *Scan) error
 }
 
 type store struct {


### PR DESCRIPTION
This change introduces the CRUD operations to manage scan configurations in the database. A scan configuration defines the rules on how to extract metrics from log files, by providing a set of patterns to match.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/116)
<!-- Reviewable:end -->
