### PR TITLE
metric,server: using stopper

### DIFF
--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -26,7 +26,9 @@ import (
 	"github.com/cockroachlabs/visus/internal/http"
 	"github.com/cockroachlabs/visus/internal/metric"
 	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
 	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/go-co-op/gocron"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -41,13 +43,15 @@ func Command() *cobra.Command {
 		Example: `
 ./visus start --bindAddr "127.0.0.1:15432" `,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
+			ctx := stopper.WithContext(cmd.Context())
+
 			if (cfg.BindCert == "" || cfg.BindKey == "") && !cfg.Insecure {
 				return errors.New("--insecure must be specfied if certificates and private key are missing")
 			}
 			if cfg.URL == "" {
 				return errors.New("--url must be specified")
 			}
+			// Set up database connections
 			conn, err := database.New(ctx, cfg.URL)
 			if err != nil {
 				return err
@@ -57,48 +61,67 @@ func Command() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
+			// Set up Prometheus registry.
 			registry := prometheus.NewRegistry()
 
-			// Run the httpServer in a separate context, so that we can
-			// control the shutdown process.
-			httpServer, err := http.New(ctx, cfg, store, registry)
+			// Start the scheduler.
+			scheduler := gocron.NewScheduler(time.UTC)
+			scheduler.StartAsync()
+			ctx.Go(func() error {
+				<-ctx.Stopping()
+				scheduler.Stop()
+				log.Info("scheduler stopped")
+				return nil
+			})
+
+			// Start the Prometheus http endpoint.
+			httpServer, err := http.New(ctx, cfg, store, registry, scheduler)
 			if err != nil {
 				return err
 			}
-			defer httpServer.Shutdown(ctx)
-			err = httpServer.Start(ctx)
-			if err != nil {
+			if err := httpServer.Start(ctx); err != nil {
 				return err
 			}
 
-			metricServer := metric.New(ctx, cfg, store, roConn, registry)
-			err = metricServer.Start(ctx)
-			if err != nil {
+			// Start the SQL metrics collector.
+			metricServer := metric.New(cfg, store, roConn, registry, scheduler)
+
+			if err := metricServer.Start(ctx); err != nil {
 				return err
 			}
-			defer metricServer.Shutdown(ctx)
 
-			signalChan := make(chan os.Signal, 1)
-			signal.Notify(signalChan, syscall.SIGHUP)
-
-			go func() {
+			// Trap SIGHUP to force configuration reload.
+			sigHup := make(chan os.Signal, 1)
+			signal.Notify(sigHup, syscall.SIGHUP)
+			ctx.Go(func() error {
+				defer close(sigHup)
+				defer signal.Stop(sigHup)
 				for {
-					s := <-signalChan
-					switch s {
-					case syscall.SIGHUP:
-						log.Info("Refreshing configuration")
-						metricServer.Refresh(ctx)
-						httpServer.Refresh(ctx)
-						roConn.Refresh(ctx)
-						conn.Refresh(ctx)
+					select {
+					case <-ctx.Stopping():
+						return nil
+					case <-sigHup:
+						// We try to refresh the various configurations.
+						// If there are errors, we log them, but we
+						// try to continue with the old configuration for
+						// any server that fails.
+						log.Info("Refreshing configuration on SIGHUP")
+						if err := metricServer.Refresh(ctx); err != nil {
+							log.Errorf("refreshing metrics %q", err)
+						}
+						if err := httpServer.Refresh(ctx); err != nil {
+							log.Errorf("refreshing http  %q", err)
+						}
+						if err := roConn.Refresh(ctx); err != nil {
+							log.Errorf("refreshing read only db connection %q", err)
+						}
+						if err := conn.Refresh(ctx); err != nil {
+							log.Errorf("refreshing db connection %q", err)
+						}
 					}
 				}
-			}()
-
-			// Wait to be shut down.
-			<-ctx.Done()
-			return nil
+			})
+			return ctx.Wait()
 		},
 	}
 	f := c.Flags()

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -19,11 +19,12 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	_ "net/http/pprof" // enabling debugging
 	"net/url"
-	"time"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
 	"github.com/cockroachlabs/visus/internal/store"
 	"github.com/cockroachlabs/visus/internal/translator"
 	"github.com/go-co-op/gocron"
@@ -37,15 +38,21 @@ type serverImpl struct {
 	config          *server.Config
 	httpServer      *http.Server
 	keyPair         *keyPair
-	translators     []translator.Translator
-	store           store.Store
-	scheduler       *gocron.Scheduler
 	registry        *prometheus.Registry
+	scheduler       *gocron.Scheduler
+	store           store.Store
+	translators     []translator.Translator
 }
+
+var _ server.Server = &serverImpl{}
 
 // New constructs a http server to server the metrics
 func New(
-	ctx context.Context, cfg *server.Config, st store.Store, registry *prometheus.Registry,
+	ctx context.Context,
+	cfg *server.Config,
+	st store.Store,
+	registry *prometheus.Registry,
+	scheduler *gocron.Scheduler,
 ) (server.Server, error) {
 	tlsConfig := &tls.Config{}
 	keyPair := &keyPair{}
@@ -77,14 +84,16 @@ func New(
 			TLSConfig: tlsConfig,
 		},
 		keyPair:     keyPair,
-		translators: make([]translator.Translator, 0),
-		store:       st,
-		scheduler:   gocron.NewScheduler(time.UTC),
 		registry:    registry,
+		scheduler:   scheduler,
+		store:       st,
+		translators: make([]translator.Translator, 0),
 	}, nil
 }
 
-func (s *serverImpl) Refresh(ctx context.Context) error {
+// Refresh implements server.Server
+func (s *serverImpl) Refresh(ctx *stopper.Context) error {
+	log.Info("Refreshing http server configuration")
 	if err := s.keyPair.load(); err != nil {
 		return err
 	}
@@ -106,7 +115,6 @@ func (s *serverImpl) Refresh(ctx context.Context) error {
 		}
 		hnew, err := translator.New(*histogram)
 		if err != nil {
-			log.Errorf("Error translating histograms %s", err)
 			continue
 		}
 		s.translators = append(s.translators, hnew)
@@ -114,14 +122,18 @@ func (s *serverImpl) Refresh(ctx context.Context) error {
 	return nil
 }
 
-// Start the server and wait for new connections.
-// It uses the default prometheus handler to return the metric value to the caller.
-func (s *serverImpl) Start(ctx context.Context) error {
-	s.scheduler.Every(s.config.Refresh).
+// Start implements server.Server
+func (s *serverImpl) Start(ctx *stopper.Context) error {
+	_, err := s.scheduler.Every(s.config.Refresh).
 		Do(func() {
-			s.Refresh(ctx)
+			err := s.Refresh(ctx)
+			if err != nil {
+				log.Errorf("Error refreshing http server %s", err.Error())
+			}
 		})
-	s.scheduler.StartAsync()
+	if err != nil {
+		return err
+	}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		if s.config.Prometheus != "" {
@@ -147,7 +159,8 @@ func (s *serverImpl) Start(ctx context.Context) error {
 	})
 
 	http.Handle(s.config.Endpoint, gziphandler.GzipHandler(handler))
-	go func() {
+
+	ctx.Go(func() error {
 		var err error
 		if !s.config.Insecure {
 			log.Infof("Starting secure server: %v", s.config.BindAddr)
@@ -157,19 +170,24 @@ func (s *serverImpl) Start(ctx context.Context) error {
 			// Server's TLSConfig.Certificates nor TLSConfig.GetCertificate are populated
 			err = s.httpServer.ListenAndServeTLS("", "")
 		} else {
-			log.Infof("Starting server: %v", s.config.BindAddr)
+			log.Infof("Http server started: %v", s.config.BindAddr)
 			err = s.httpServer.ListenAndServe()
 		}
 		if err != http.ErrServerClosed {
-			log.Fatal("Error starting server: ", err)
+			log.Errorf("Error starting server: %s", err)
 		}
-	}()
+		return nil
+	})
+	ctx.Go(func() error {
+		<-ctx.Stopping()
+		if err := s.httpServer.Shutdown(ctx); err != nil {
+			log.WithError(err).Error("did not shut down cleanly")
+		} else {
+			log.Info("Http server stopped")
+		}
+		return nil
+	})
 	return nil
-}
-
-func (s *serverImpl) Shutdown(ctx context.Context) error {
-	log.Info("Shutting down ")
-	return s.httpServer.Shutdown(ctx)
 }
 
 func (s *serverImpl) errorResponse(w http.ResponseWriter, msg string, err error) {

--- a/internal/metric/server.go
+++ b/internal/metric/server.go
@@ -16,12 +16,13 @@
 package metric
 
 import (
-	"context"
+	"sync"
 	"time"
 
 	"github.com/cockroachlabs/visus/internal/collector"
 	"github.com/cockroachlabs/visus/internal/database"
 	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
 	"github.com/cockroachlabs/visus/internal/store"
 	"github.com/go-co-op/gocron"
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,21 +40,25 @@ type metricsServer struct {
 	config           *server.Config
 	conn             database.Connection
 	store            store.Store
-	scheduledJobs    map[string]*scheduledJob
 	scheduler        *gocron.Scheduler
 	registry         *prometheus.Registry
 	collectorCount   *prometheus.CounterVec
 	collectorErrors  *prometheus.CounterVec
 	collectorLatency *prometheus.HistogramVec
+	mu               struct {
+		sync.RWMutex
+		scheduledJobs map[string]*scheduledJob
+		stopped       bool
+	}
 }
 
 // New creates a new server to collect the metrics.
 func New(
-	ctx context.Context,
 	cfg *server.Config,
 	store store.Store,
 	conn database.Connection,
 	registry *prometheus.Registry,
+	scheduler *gocron.Scheduler,
 ) server.Server {
 	var collectorCounts, collectorErrors *prometheus.CounterVec
 	var collectorLatency *prometheus.HistogramVec
@@ -98,39 +103,32 @@ func New(
 		registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	}
 	server := &metricsServer{
-		config:           cfg,
-		conn:             conn,
-		store:            store,
 		collectorCount:   collectorCounts,
 		collectorErrors:  collectorErrors,
 		collectorLatency: collectorLatency,
-		scheduler:        gocron.NewScheduler(time.UTC),
-		scheduledJobs:    make(map[string]*scheduledJob),
+		config:           cfg,
+		conn:             conn,
 		registry:         registry,
+		scheduler:        scheduler,
+		store:            store,
 	}
+
+	server.mu.stopped = true
+	server.mu.scheduledJobs = make(map[string]*scheduledJob)
 	return server
 }
 
-// addJob add a new collector to the scheduler.
-func (m *metricsServer) addJob(name string, coll collector.Collector, job *gocron.Job) {
-	m.scheduledJobs[name] = &scheduledJob{
-		collector: coll,
-		job:       job,
-	}
-}
-
-// refresh schedules all the collectors based on the
-// configuration stored in the database.
-func (m *metricsServer) Refresh(ctx context.Context) error {
+// Refresh implements server.Server
+func (m *metricsServer) Refresh(ctx *stopper.Context) error {
 	newCollectors := make(map[string]bool)
 	names, err := m.store.GetCollectionNames(ctx)
 	if err != nil {
 		return err
 	}
+	log.Info("Refreshing metrics")
 	last := time.Now().UTC().Add(-m.config.Refresh)
 	isMainNode, err := m.store.IsMainNode(ctx, last)
 	if err != nil {
-
 		return err
 	}
 	for _, name := range names {
@@ -144,13 +142,13 @@ func (m *metricsServer) Refresh(ctx context.Context) error {
 			continue
 		}
 		newCollectors[name] = true
-		existing, found := m.scheduledJobs[coll.Name]
+		existing, found := m.getJob(coll.Name)
 		if found && !existing.collector.GetLastModified().Before(coll.LastModified.Time) {
-			log.Debugf("Already scheduled %s, no change", coll.Name)
+			log.Debugf("Already scheduled %s", coll.Name)
 			continue
 		}
 		if found {
-			log.Debugf("Already scheduled %s, removing", coll.Name)
+			log.Infof("Configuration for %s has changed", coll.Name)
 			m.scheduler.RemoveByReference(existing.job)
 		}
 		collctr, err := collector.FromCollection(coll, m.registry)
@@ -162,7 +160,6 @@ func (m *metricsServer) Refresh(ctx context.Context) error {
 		job, err := m.scheduler.Every(collctr.GetFrequency()).Second().
 			Do(func(collctr collector.Collector) {
 				name := collctr.String()
-				log.Debugf("Running collector %s", name)
 				start := time.Now()
 				err := collctr.Collect(ctx, m.conn)
 				if err != nil {
@@ -171,7 +168,7 @@ func (m *metricsServer) Refresh(ctx context.Context) error {
 					}
 					log.Errorf("collector %s: %s", collctr, err.Error())
 				}
-				if m.collectorCount != nil {
+				if m.config.VisusMetrics {
 					elapsed := time.Since(start).Milliseconds()
 					m.collectorLatency.WithLabelValues(name).Observe(float64(elapsed))
 					m.collectorCount.WithLabelValues(name).Inc()
@@ -183,34 +180,55 @@ func (m *metricsServer) Refresh(ctx context.Context) error {
 		}
 		m.addJob(coll.Name, collctr, job)
 	}
-	// remove all the schedule jobs that have been deleted from the database.
-	for key, value := range m.scheduledJobs {
-		if _, ok := newCollectors[key]; !ok {
-			log.Infof("Removing collector: %s", key)
-			m.scheduler.RemoveByReference(value.job)
-			value.collector.Unregister()
-			delete(m.scheduledJobs, key)
-		}
-	}
+	m.cleanupJobs(newCollectors)
 	return nil
 }
 
 // Start schedules all the collectors.
-func (m *metricsServer) Start(ctx context.Context) error {
-	m.scheduler.Every(m.config.Refresh).
+func (m *metricsServer) Start(ctx *stopper.Context) error {
+	// If we don't have a scheduler, we force a refresh and we are done.
+	// Used for testing.
+	if m.scheduler == nil {
+		return m.Refresh(ctx)
+	}
+	_, err := m.scheduler.Every(m.config.Refresh).
 		Do(func() {
 			err := m.Refresh(ctx)
 			if err != nil {
-				log.Errorf("Error in refresh %s", err.Error())
+				log.Errorf("Error refreshing metrics %s", err.Error())
 			}
 		})
-	m.scheduler.StartAsync()
-	return nil
+	return err
 }
 
-// Shutdown gracefully stops all the collectors.
-func (m *metricsServer) Shutdown(ctx context.Context) error {
-	m.scheduler.Stop()
-	m.scheduler.Clear()
-	return nil
+// addJob add a new collector to the scheduler.
+func (m *metricsServer) addJob(name string, coll collector.Collector, job *gocron.Job) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.scheduledJobs[name] = &scheduledJob{
+		collector: coll,
+		job:       job,
+	}
+}
+
+// cleanupJobs removes all the jobs that we don't need to keep.
+func (m *metricsServer) cleanupJobs(toKeep map[string]bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, value := range m.mu.scheduledJobs {
+		if _, ok := toKeep[key]; !ok {
+			log.Infof("Removing collector: %s", key)
+			m.scheduler.RemoveByReference(value.job)
+			value.collector.Unregister()
+			delete(m.mu.scheduledJobs, key)
+		}
+	}
+}
+
+// getJob the named job.
+func (m *metricsServer) getJob(name string) (*scheduledJob, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	job, ok := m.mu.scheduledJobs[name]
+	return job, ok
 }

--- a/internal/metric/server_test.go
+++ b/internal/metric/server_test.go
@@ -1,0 +1,210 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/database"
+	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/go-co-op/gocron"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pashagolub/pgxmock/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dbQuery    = "SELECT database, count FROM databases LIMIT $1"
+	statsQuery = "SELECT statement, count FROM statements LIMIT $1"
+)
+
+func TestRefreshCollectors(t *testing.T) {
+	r := require.New(t)
+	a := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stop := stopper.WithContext(ctx)
+	conn := &mockDB{}
+	mockStore := &store.Memory{}
+	mockStore.Init(ctx)
+	cfg := &server.Config{}
+	registry := prometheus.NewRegistry()
+	server := &metricsServer{
+		config:    cfg,
+		conn:      conn,
+		store:     mockStore,
+		scheduler: gocron.NewScheduler(time.UTC),
+		registry:  registry,
+	}
+	server.mu.stopped = true
+	server.mu.scheduledJobs = make(map[string]*scheduledJob)
+	server.scheduler.StartAsync()
+	// Adding a collection
+	dbTime := time.Now()
+	dbColl := &store.Collection{
+		Enabled: true,
+		Frequency: pgtype.Interval{
+			Microseconds: 1e6,
+			Valid:        true,
+		},
+		Labels: []string{"database"},
+		LastModified: pgtype.Timestamp{
+			Time:  dbTime,
+			Valid: true,
+		},
+		MaxResult: 1,
+		Metrics: []store.Metric{
+			{
+				Name: "count",
+				Kind: store.Counter,
+				Help: "num of databases",
+			},
+		},
+		Name:  "databases",
+		Query: dbQuery,
+	}
+	err := mockStore.PutCollection(ctx, dbColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok := server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+	// Modify the collection
+	dbTime = time.Now()
+	dbColl.LastModified.Time = dbTime
+	err = mockStore.PutCollection(ctx, dbColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+	// Add a new collection
+	sqlTime := time.Now()
+	sqlColl := &store.Collection{
+		Enabled: true,
+		Frequency: pgtype.Interval{
+			Microseconds: 1e6,
+			Valid:        true,
+		},
+		Labels: []string{"statement"},
+		LastModified: pgtype.Timestamp{
+			Time:  sqlTime,
+			Valid: true,
+		},
+		MaxResult: 1,
+		Metrics: []store.Metric{
+			{
+				Name: "count",
+				Kind: store.Counter,
+				Help: "num of statements",
+			},
+		},
+		Name:  "statements",
+		Query: statsQuery,
+	}
+	err = mockStore.PutCollection(ctx, sqlColl)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.True(ok)
+	a.Equal(coll.collector.GetLastModified(), dbTime)
+	sqlJob, ok := server.getJob(sqlColl.Name)
+	r.True(ok)
+	a.Equal(sqlJob.collector.GetLastModified(), sqlTime)
+	a.Equal(2, len(server.scheduler.Jobs()))
+	// Sleep just few seconds, make sure we see metrics
+	time.Sleep(2 * time.Second)
+	metrics, err := registry.Gather()
+	r.NoError(err)
+	a.Equal(2, len(metrics))
+	for _, m := range metrics {
+		a.Contains([]string{"databases_count", "statements_count"}, *m.Name)
+	}
+
+	// Remove the first collection
+	err = mockStore.DeleteCollection(ctx, dbColl.Name)
+	r.NoError(err)
+	err = server.Refresh(stop)
+	r.NoError(err)
+	coll, ok = server.getJob(dbColl.Name)
+	r.False(ok)
+	a.Nil(coll)
+	sqlJob, ok = server.getJob(sqlColl.Name)
+	r.True(ok)
+	a.Equal(sqlJob.collector.GetLastModified(), sqlTime)
+	a.Equal(1, len(server.scheduler.Jobs()))
+
+}
+
+type mockDB struct {
+	dbcount, statscount atomic.Int32
+}
+
+var _ database.Connection = &mockDB{}
+
+// Begin implements database.Connection.
+func (m *mockDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	panic("unimplemented")
+}
+
+// Exec implements database.Connection.
+func (m *mockDB) Exec(
+	ctx context.Context, sql string, arguments ...interface{},
+) (pgconn.CommandTag, error) {
+	panic("unimplemented")
+}
+
+// Query implements database.Connection.
+func (m *mockDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	conn, err := pgxmock.NewConn()
+	if err != nil {
+		return nil, err
+	}
+	query := conn.ExpectQuery(strings.Replace(sql, "LIMIT $1", ".+", 1)).WithArgs(1)
+	switch sql {
+	case dbQuery:
+		m.dbcount.Add(1)
+		res := conn.NewRows([]string{"database", "count"})
+		res.AddRow("test", int(m.dbcount.Load()))
+		query.WillReturnRows(res)
+	case statsQuery:
+		m.statscount.Add(1)
+		res := conn.NewRows([]string{"statement", "count"})
+		res.AddRow("st1", int(m.statscount.Load()))
+		query.WillReturnRows(res)
+	}
+	return conn.Query(ctx, sql, args...)
+}
+
+// QueryRow implements database.Connection.
+func (m *mockDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	panic("unimplemented")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package server implements an http server to export metrics in Prometheus format.
+// Package server manages access to a resource
 package server
 
-import "context"
+import "github.com/cockroachlabs/visus/internal/stopper"
 
-// A Server is a process that can be started and shutdown.
+// The Server interface manages the lifecycle of a process that controls access to a resource.
+// Its configuration can be refreshed.
+// It uses the stopper interface to manage graceful shutdown.
 type Server interface {
-	// Refresh the server configuration
-	Refresh(ctx context.Context) error
-	// Start the server
-	Start(ctx context.Context) error
-	// Shutdown the server, releasing all the resources associated with it.
-	Shutdown(ctx context.Context) error
+	Start(ctx *stopper.Context) error
+	Refresh(ctx *stopper.Context) error
 }

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachlabs/visus/internal/cmd/histogram"
 	"github.com/cockroachlabs/visus/internal/cmd/initialize"
 	"github.com/cockroachlabs/visus/internal/cmd/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
 	joonix "github.com/joonix/log"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -95,12 +96,30 @@ func main() {
 	root.AddCommand(collection.Command())
 	root.AddCommand(histogram.Command())
 	root.AddCommand(initialize.Command())
+	gracePeriod := 5 * time.Second
+	stop := stopper.WithContext(context.Background())
+	// Stop cleanly on interrupt.
+	stop.Go(func() error {
+		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+		defer cancel()
+		select {
+		case <-ctx.Done():
+			log.Info("Interrupted")
+			stop.Stop(gracePeriod)
+		case <-stop.Stopping():
+			// Nothing to do.
+		}
+		return nil
+	})
+	// Allow log.Exit() or log.Fatal() to trigger shutdown.
+	log.DeferExitHandler(func() {
+		stop.Stop(gracePeriod)
+		<-stop.Done()
+	})
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel()
-
-	if err := root.ExecuteContext(ctx); err != nil {
-		log.WithError(err).Error("could not execute command")
+	// Passing the stopper down to the commands.
+	if err := root.ExecuteContext(stop); err != nil {
+		log.WithError(err).Error("exited")
 		log.Exit(1)
 	}
 	log.Exit(0)


### PR DESCRIPTION
Previously, we were using the Server interface to start/refresh/shutdown services.
With this change, we will be using the stopper.Stopper context to manage
services lifetime, and allow graceful termination.
The scheduler has also moved out of the metrics server, so its lifecycle can be managed
at the same level at other services.

As part of this change, we are adding test cases for the metrics server.
The list of scheduled job has been protected by a mutex.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/117)
<!-- Reviewable:end -->
