### PR TITLE
log scanner: adding cli to managing scans.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/joonix/log v0.0.0-20230221083239-7988383bab32
+	github.com/nxadm/tail v1.4.11
 	github.com/pashagolub/pgxmock/v3 v3.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
@@ -32,6 +33,7 @@ require (
 	github.com/cockroachdb/gostdlib v1.19.0 // indirect
 	github.com/cockroachdb/ttycolor v0.0.0-20210902133924-c7d7dcdde4e8 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -50,4 +52,5 @@ require (
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto v0.0.0-20231030173426-d783a09b4405 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -449,6 +449,8 @@ github.com/envoyproxy/go-control-plane v0.10.3/go.mod h1:fJJn/j26vwOu972OllsvAgJ
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-co-op/gocron v1.37.0 h1:ZYDJGtQ4OMhTLKOKMIch+/CY70Brbb1dGdooLEhh7b0=
 github.com/go-co-op/gocron v1.37.0/go.mod h1:3L/n6BkO7ABj+TrfSVXLRzsP26zmikL4ISkLQ0O8iNY=
@@ -587,6 +589,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
+github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
+github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/pashagolub/pgxmock/v3 v3.4.0 h1:87VMr2q7m2+6VzXo4Tsp9kMklGlj6mMN19Hp/bp2Rwo=
 github.com/pashagolub/pgxmock/v3 v3.4.0/go.mod h1:FvCl7xqPbLLI3XohihJ1NzXnikjM3q/NWSixg4t9hrU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -876,6 +880,7 @@ golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1210,6 +1215,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cmd/scan/admin.go
+++ b/internal/cmd/scan/admin.go
@@ -1,0 +1,320 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scan defines the sub command to run visus scan utilities.
+package scan
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/database"
+	"github.com/cockroachlabs/visus/internal/scanner"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/creasty/defaults"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var databaseURL = ""
+
+// patternDef yaml pattern definition
+type patternDef struct {
+	Help  string
+	Name  string
+	Regex string
+}
+
+// config yaml scan definition
+type config struct {
+	Enabled  bool
+	Format   string
+	Name     string
+	Path     string
+	Patterns []patternDef
+}
+
+func marshal(logFile *store.Scan) ([]byte, error) {
+	patterns := make([]patternDef, 0)
+	for _, m := range logFile.Patterns {
+		metric := patternDef{
+			Help:  m.Help,
+			Name:  m.Name,
+			Regex: m.Regex,
+		}
+		patterns = append(patterns, metric)
+	}
+	config := &config{
+		Enabled:  logFile.Enabled,
+		Format:   string(logFile.Format),
+		Name:     logFile.Name,
+		Path:     logFile.Path,
+		Patterns: patterns,
+	}
+	return yaml.Marshal(config)
+}
+
+// listCmd list all the log scans in the database
+func listCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "list",
+		Example: `./visus scan list  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := database.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			store := store.New(conn)
+			logs, err := store.GetScanNames(ctx)
+			if err != nil {
+				fmt.Print("Error retrieving log targets")
+				return err
+			}
+			for _, lg := range logs {
+				fmt.Printf("%s\n", lg)
+			}
+			return nil
+		},
+	}
+	return c
+}
+
+// getCmd retrieves a scan configuration from the database.
+func getCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "get",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan get scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			logName := args[0]
+			conn, err := database.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			store := store.New(conn)
+			scanner, err := store.GetScan(ctx, logName)
+			if err != nil {
+				fmt.Printf("Error retrieving log %s.", logName)
+				return err
+			}
+			if scanner == nil {
+				fmt.Printf("Scan %s not found\n", logName)
+			} else {
+				res, err := marshal(scanner)
+				if err != nil {
+					fmt.Printf("Unabled to marshall %s\n", logName)
+				}
+				fmt.Println(string(res))
+			}
+			return nil
+		},
+	}
+	return c
+}
+
+// testCmd retrieves a scan configuration and execute it, returning the metrics extracted
+// from the log file in the scan.
+func testCmd() *cobra.Command {
+	var interval time.Duration
+	var count int
+	c := &cobra.Command{
+		Use:     "test",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan test scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := stopper.WithContext(cmd.Context())
+			logName := args[0]
+			conn, err := database.ReadOnly(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			st := store.New(conn)
+			lg, err := st.GetScan(ctx, logName)
+			if err != nil {
+				fmt.Printf("Error retrieving scan %s.", logName)
+				return err
+			}
+			if lg == nil {
+				fmt.Printf("Scan %s not found\n", logName)
+			} else {
+				scanner, err := scanner.FromConfig(lg,
+					&scanner.Config{
+						FromBeginning: true,
+						Poll:          true,
+						Follow:        false,
+					},
+					prometheus.DefaultRegisterer)
+				if err != nil {
+					return err
+				}
+				scanner.Start(ctx)
+				for i := 1; i <= count || count == 0; i++ {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-time.After(interval):
+					}
+					gathering, err := prometheus.DefaultGatherer.Gather()
+					if err != nil {
+						fmt.Printf("Error retrieving patterns %s.", err)
+						return err
+					}
+					fmt.Printf("\n---- %s %s -----\n", time.Now().Format("01-02-2006 15:04:05"), lg.Name)
+					for _, mf := range gathering {
+						if strings.HasPrefix(*mf.Name, logName) {
+							expfmt.MetricFamilyToText(os.Stdout, mf)
+
+						}
+					}
+				}
+				return scanner.Stop()
+			}
+			return nil
+		},
+	}
+	f := c.Flags()
+	f.DurationVar(&interval, "interval", 10*time.Second, "interval of scan")
+	f.IntVar(&count, "count", 1, "number of times to run the scan. Specify 0 for continuos scan")
+	return c
+}
+
+// deleteCmd deletes a scan from the database.
+func deleteCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "delete",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan delete scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			logName := args[0]
+			conn, err := database.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			store := store.New(conn)
+			err = store.DeleteScan(ctx, args[0])
+			if err != nil {
+				fmt.Printf("Error deleting scan %s.\n", logName)
+				return err
+			}
+			fmt.Printf("Scan %s deleted.\n", logName)
+			return nil
+		},
+	}
+	return c
+}
+
+// putCmd inserts a new scan in the database using the specified yaml configuration.
+func putCmd() *cobra.Command {
+	var file string
+	c := &cobra.Command{
+		Use:     "put",
+		Args:    cobra.ExactArgs(0),
+		Example: `./visus scan put --yaml config.yaml --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if file == "" {
+				return errors.New("yaml configuration required")
+			}
+			conn, err := database.New(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			var data []byte
+			if file == "-" {
+				var buffer bytes.Buffer
+				scanner := bufio.NewScanner(os.Stdin)
+				for scanner.Scan() {
+					buffer.Write(scanner.Bytes())
+					buffer.WriteString("\n")
+				}
+				if err := scanner.Err(); err != nil {
+					log.Errorf("reading standard input: %s", err.Error())
+				}
+				data = buffer.Bytes()
+			} else {
+				data, err = os.ReadFile(file)
+				if err != nil {
+					return err
+				}
+			}
+			config := &config{}
+			err = yaml.Unmarshal(data, &config)
+			if err != nil {
+				return err
+			}
+			if err := defaults.Set(config); err != nil {
+				return err
+			}
+			patterns := make([]store.Pattern, 0)
+			for _, p := range config.Patterns {
+				pattern := store.Pattern{
+					Name:  p.Name,
+					Regex: p.Regex,
+					Help:  p.Help,
+				}
+				patterns = append(patterns, pattern)
+			}
+			if config.Name == "" {
+				return errors.New("name must be specified")
+			}
+			logTarget := &store.Scan{
+				Enabled:  config.Enabled,
+				Format:   store.LogFormat(config.Format),
+				Path:     config.Path,
+				Name:     config.Name,
+				Patterns: patterns,
+			}
+			store := store.New(conn)
+			err = store.PutScan(ctx, logTarget)
+			if err != nil {
+				fmt.Printf("Error inserting scan %s.", config.Name)
+				return err
+			}
+			fmt.Printf("Scan %s inserted.\n", config.Name)
+			return nil
+		},
+	}
+	f := c.Flags()
+	f.StringVar(&file, "yaml", "", "file containing the configuration")
+	return c
+}
+
+// Command runs the scan tools to view and manage the configuration in the database.
+func Command() *cobra.Command {
+	c := &cobra.Command{
+		Use: "scan",
+	}
+	f := c.PersistentFlags()
+	c.AddCommand(
+		getCmd(),
+		listCmd(),
+		deleteCmd(),
+		putCmd(),
+		testCmd())
+	f.StringVar(&databaseURL, "url", "",
+		"Connection URL, of the form: postgresql://[user[:passwd]@]host[:port]/[db][?parameters...]")
+	return c
+}

--- a/internal/scanner/crdbv2.go
+++ b/internal/scanner/crdbv2.go
@@ -1,0 +1,50 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/nxadm/tail"
+)
+
+var crdbPrefix = regexp.MustCompile("^[FEIW][0-9][0-9][0-9][0-9][0-9][0-9] ")
+
+// scanCockroachLog scan a cockroach log.
+func scanCockroachLog(_ context.Context, tail *tail.Tail, metrics map[string]*Metric) error {
+	for line := range tail.Lines {
+		for _, m := range metrics {
+			if !crdbPrefix.Match([]byte(line.Text)) {
+				continue
+			}
+			if m.regex.Match([]byte(line.Text)) {
+				fields := strings.Split(line.Text, " ")
+				module := ""
+				if len(fields) >= 4 {
+					_, after, found := strings.Cut(fields[3], "@")
+					if found {
+						module, _, _ = strings.Cut(after, ":")
+					} else {
+						module, _, _ = strings.Cut(fields[3], ":")
+					}
+				}
+				m.counter.WithLabelValues(string(line.Text[0]), module).Inc()
+			}
+		}
+	}
+	return nil
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -128,13 +128,6 @@ func (s *Scanner) Stop() error {
 	return t.Stop()
 }
 
-// Stopped returns true if the scanner is done.
-func (s *Scanner) Stopped() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.mu.tail == nil
-}
-
 // addCounter adds a metric counter to the Prometheus registry.
 // The counter track the number of lines matching the pattern.
 func (s *Scanner) addCounter(pattern store.Pattern) error {
@@ -186,4 +179,11 @@ func (s *Scanner) open() (*tail.Tail, error) {
 			Poll:     s.config.Poll,
 		})
 	return s.mu.tail, err
+}
+
+// Stopped returns true if the scanner is done.
+func (s *Scanner) stopped() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.tail == nil
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,189 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scanner parses log files
+package scanner
+
+import (
+	"context"
+	"io"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/nxadm/tail"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+// Config defines the behavior of the scanner
+type Config struct {
+	Follow        bool
+	FromBeginning bool
+	Poll          bool
+	Reopen        bool
+}
+
+// Metric defines the prometheus counter to increment when a line matches the regular expression.
+type Metric struct {
+	counter *prometheus.CounterVec
+	regex   *regexp.Regexp
+}
+
+// Scanner scans a log file to extract the given metrics.
+type Scanner struct {
+	config     *Config
+	metrics    map[string]*Metric
+	registerer prometheus.Registerer
+	target     *store.Scan
+	parser     Parse
+	mu         struct {
+		sync.RWMutex
+		tail *tail.Tail
+	}
+}
+
+// Parse implements the custom logic to parse a specific log file type.
+type Parse func(context.Context, *tail.Tail, map[string]*Metric) error
+
+// FromConfig creates a new scanner, based on the configuration provided.
+func FromConfig(
+	scan *store.Scan, config *Config, registerer prometheus.Registerer,
+) (*Scanner, error) {
+	scanner := &Scanner{
+		config:     config,
+		metrics:    make(map[string]*Metric),
+		registerer: registerer,
+		target:     scan,
+	}
+	for _, p := range scan.Patterns {
+		err := scanner.addCounter(p)
+		if err != nil {
+			return nil, err
+		}
+	}
+	switch scan.Format {
+	case store.CRDBV2:
+		scanner.parser = scanCockroachLog
+	default:
+		return nil, errors.Errorf("format not supported %s", scan.Format)
+	}
+	return scanner, nil
+}
+
+// GetLastModified returns the last time the scanner configuration was updated.
+func (s *Scanner) GetLastModified() time.Time {
+	return s.target.LastModified.Time
+}
+
+// Start scanning the log
+func (s *Scanner) Start(ctx *stopper.Context) error {
+	ctx.Go(func() error {
+		tail, err := s.open()
+		if err != nil {
+			log.Errorf("Scanner %s failed. %s", s.target.Name, err.Error())
+			return errors.WithStack(err)
+		}
+		log.Infof("Scanner %s started", s.target.Name)
+		err = s.parser(ctx, tail, s.metrics)
+		if err != nil {
+			log.Errorf("Scanner %s failed. %s", s.target.Name, err.Error())
+			errors.WithStack(err)
+		}
+		return nil
+	})
+	ctx.Go(func() error {
+		<-ctx.Stopping()
+		s.Stop()
+		log.Infof("Scanner %s stopped", s.target.Name)
+		return nil
+	})
+	return nil
+}
+
+// Stop stops the scanning activity.
+func (s *Scanner) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.tail == nil {
+		return nil
+	}
+	t := s.mu.tail
+	s.mu.tail = nil
+	defer t.Cleanup()
+	return t.Stop()
+}
+
+// Stopped returns true if the scanner is done.
+func (s *Scanner) Stopped() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.tail == nil
+}
+
+// addCounter adds a metric counter to the Prometheus registry.
+// The counter track the number of lines matching the pattern.
+func (s *Scanner) addCounter(pattern store.Pattern) error {
+	metricName := s.target.Name + "_" + pattern.Name
+	vec := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: metricName,
+			Help: pattern.Help,
+		},
+		[]string{"level", "source"},
+	)
+	s.registerer.Unregister(vec)
+	if err := s.registerer.Register(vec); err != nil {
+		return err
+	}
+	regex, err := regexp.Compile(pattern.Regex)
+	if err != nil {
+		return err
+	}
+	log.Debugf("registering counter %s (%s)", metricName, pattern.Regex)
+	s.metrics[pattern.Name] = &Metric{
+		counter: vec,
+		regex:   regex,
+	}
+	return nil
+}
+
+// open the file for scanning
+func (s *Scanner) open() (*tail.Tail, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.tail != nil {
+		return nil, errors.Errorf("scanner already running for %s", s.target.Path)
+	}
+	var location *tail.SeekInfo
+	if !s.config.FromBeginning {
+		location = &tail.SeekInfo{
+			Offset: 0,
+			Whence: io.SeekEnd,
+		}
+	}
+	var err error
+	s.mu.tail, err = tail.TailFile(
+		s.target.Path, tail.Config{
+			Logger:   log.StandardLogger(),
+			Follow:   s.config.Follow,
+			ReOpen:   s.config.Follow,
+			Location: location,
+			Poll:     s.config.Poll,
+		})
+	return s.mu.tail, err
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,143 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"bytes"
+	"context"
+	_ "embed" // embedding sql statements
+	"testing"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testVerify(t *testing.T, expected map[string]string) {
+	gathering, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range gathering {
+		toCheck, ok := expected[*mf.Name]
+		if ok {
+			out := bytes.NewBufferString("")
+			expfmt.MetricFamilyToText(out, mf)
+			assert.Equal(t, toCheck, out.String())
+		}
+	}
+}
+
+//go:embed testdata/all.txt
+var allExpected string
+
+//go:embed testdata/regex.txt
+var regexExpected string
+
+//go:embed testdata/max.txt
+var maxExpected string
+
+//go:embed testdata/cache.txt
+var cacheExpected string
+
+// TestScanner verifies we can produce metrics from a test file.
+func TestScanner(t *testing.T) {
+	tests := []struct {
+		name   string
+		target *store.Scan
+		want   map[string]string
+	}{
+		{
+			"all",
+			&store.Scan{
+				Enabled: true,
+				Format:  store.CRDBV2,
+				Name:    "crdb",
+				Path:    "./testdata/sample.log",
+				Patterns: []store.Pattern{
+					{
+						Name:  "all",
+						Regex: "",
+						Help:  "all events",
+					},
+				},
+			},
+			map[string]string{
+				"crdb_all": allExpected,
+			},
+		},
+		{
+			"regex",
+			&store.Scan{
+				Enabled: true,
+				Format:  store.CRDBV2,
+				Name:    "crdb",
+				Path:    "./testdata/sample.log",
+				Patterns: []store.Pattern{
+					{
+						Name:  "size",
+						Regex: "(cache|max) size",
+						Help:  "size events",
+					},
+				},
+			},
+			map[string]string{
+				"crdb_size": regexExpected,
+			},
+		},
+		{
+			"multiple regex",
+			&store.Scan{
+				Enabled: true,
+				Format:  store.CRDBV2,
+				Name:    "crdb",
+				Path:    "./testdata/sample.log",
+				Patterns: []store.Pattern{
+					{
+						Name:  "cache",
+						Regex: "cache size",
+						Help:  "cache events",
+					},
+					{
+						Name:  "max",
+						Regex: "max size",
+						Help:  "max events",
+					},
+				},
+			},
+			map[string]string{
+				"crdb_max":   maxExpected,
+				"crdb_cache": cacheExpected,
+			},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			s, err := FromConfig(tt.target, &Config{
+				FromBeginning: true,
+			}, prometheus.DefaultRegisterer)
+			r.NoError(err)
+			tail, err := s.open()
+			r.NoError(err)
+			err = s.parser(ctx, tail, s.metrics)
+			r.NoError(err)
+			testVerify(t, tt.want)
+		})
+	}
+}

--- a/internal/scanner/server.go
+++ b/internal/scanner/server.go
@@ -1,0 +1,177 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"sync"
+
+	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/go-co-op/gocron"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+type scannerServer struct {
+	config        *server.Config       // configuration
+	fromBeginning bool                 // used for testing, read logs from beginning.
+	registry      *prometheus.Registry // metrics registry
+	scheduler     *gocron.Scheduler    // the scheduler for refreshing the configuration.
+	store         store.Store          // store that contains the configuration of the scans.
+
+	mu struct {
+		sync.RWMutex
+		scanners map[string]*Scanner
+	}
+}
+
+var _ server.Server = &scannerServer{}
+
+// New returns a server that manages scanners.
+func New(
+	cfg *server.Config, store store.Store, registry *prometheus.Registry, scheduler *gocron.Scheduler,
+) server.Server {
+	scanners := &scannerServer{
+		config:    cfg,
+		registry:  registry,
+		scheduler: scheduler,
+		store:     store,
+	}
+	scanners.mu.scanners = make(map[string]*Scanner)
+	return scanners
+}
+
+// Refresh implements server.Server
+func (s *scannerServer) Refresh(ctx *stopper.Context) error {
+	log.Info("Refreshing scanners configuration")
+	err := s.refresh(ctx)
+	if err != nil {
+		server.RefreshErrors.WithLabelValues("scanners").Inc()
+	}
+	server.RefreshCounts.WithLabelValues("scanners").Inc()
+	return nil
+}
+
+// Start implements server.Server.
+func (s *scannerServer) Start(ctx *stopper.Context) error {
+	// If we don't have a scheduler, we force a refresh and we are done.
+	if s.scheduler == nil {
+		return s.Refresh(ctx)
+	}
+	_, err := s.scheduler.Every(s.config.Refresh).
+		Do(func() {
+			err := s.Refresh(ctx)
+			if err != nil {
+				log.Errorf("Error refreshing scanners %s", err.Error())
+			}
+		})
+	return err
+}
+
+// add the named scanner
+func (s *scannerServer) add(name string, scanner *Scanner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.scanners[name] = scanner
+}
+
+// buildScanner creates a new scanner.
+func (s *scannerServer) buildScanner(name string, scan *store.Scan) (*Scanner, error) {
+	scanner, err := FromConfig(scan, &Config{
+		Follow:        true,
+		FromBeginning: s.fromBeginning,
+		Poll:          !s.config.Inotify,
+		Reopen:        true,
+	}, s.registry)
+	if err != nil {
+		return nil, err
+	}
+	s.add(name, scanner)
+	return scanner, nil
+}
+
+// cleanup removes all the scanners that we don't need to keep.
+func (s *scannerServer) cleanup(toKeep map[string]bool) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, value := range s.mu.scanners {
+		if _, ok := toKeep[key]; !ok {
+			log.Infof("Removing scanner %s", key)
+			err = value.Stop()
+			if err != nil {
+				return
+			}
+			delete(s.mu.scanners, key)
+		}
+	}
+	return
+}
+
+// delete the named scanner
+func (s *scannerServer) delete(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.mu.scanners, name)
+}
+
+// get returns the named scanner.
+func (s *scannerServer) get(name string) (*Scanner, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sc, ok := s.mu.scanners[name]
+	return sc, ok
+}
+
+// refresh the scanners configuration.
+func (s *scannerServer) refresh(ctx *stopper.Context) error {
+	newScans := make(map[string]bool)
+	names, err := s.store.GetScanNames(ctx)
+	if err != nil {
+		return err
+	}
+	log.Info("Refreshing scanners")
+	for _, name := range names {
+		scan, err := s.store.GetScan(ctx, name)
+		if err != nil {
+			log.Errorf("Unable to find %s: %s", name, err.Error())
+			continue
+		}
+		log.Debugf("Considering %s; enabled=%t;", name, scan.Enabled)
+		if !scan.Enabled {
+			continue
+		}
+		newScans[name] = true
+		existing, found := s.get(name)
+		if found && !existing.GetLastModified().Before(scan.LastModified.Time) {
+			log.Debugf("Already scheduled %s, no change", scan.Name)
+			continue
+		}
+		if found {
+			log.Infof("Configuration for %s has changed", scan.Name)
+			existing.Stop()
+		}
+		scanner, err := s.buildScanner(scan.Name, scan)
+		if err != nil {
+			log.Errorf("Error adding scanner %s: %s", name, err.Error())
+			continue
+		}
+		if err := scanner.Start(ctx); err != nil {
+			s.delete(scan.Name)
+			log.Errorf("Error starting scanner %s: %s", name, err.Error())
+		}
+	}
+	return s.cleanup(newScans)
+}

--- a/internal/scanner/server_test.go
+++ b/internal/scanner/server_test.go
@@ -1,0 +1,200 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/server"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshScanners(t *testing.T) {
+	r := require.New(t)
+	a := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stopperCtx := stopper.WithContext(ctx)
+	mockStore := &store.Memory{}
+	mockStore.Init(ctx)
+	cfg := &server.Config{}
+	registry := prometheus.NewRegistry()
+	scanners := &scannerServer{
+		config:        cfg,
+		fromBeginning: true,
+		registry:      registry,
+		store:         mockStore,
+	}
+	scanners.mu.scanners = make(map[string]*Scanner)
+
+	now := time.Now()
+	crdbScan := &store.Scan{
+		Enabled: true,
+		Format:  store.CRDBV2,
+		LastModified: pgtype.Timestamp{
+			Time:  now,
+			Valid: true,
+		},
+		Name: "crdblog",
+		Path: "./testdata/sample.log",
+		Patterns: []store.Pattern{
+			{
+				Name:  "cache",
+				Regex: "cache size",
+				Help:  "cache events",
+			},
+			{
+				Name:  "max",
+				Regex: "max size",
+				Help:  "max events",
+			},
+		},
+	}
+	// Adding the scan to the store
+	mockStore.PutScan(ctx, crdbScan)
+	// Start the scanner
+	err := scanners.Start(stopperCtx)
+	r.NoError(err)
+	// Making sure that the scan was added
+	crdbScanner, ok := scanners.get(crdbScan.Name)
+	r.True(ok)
+	a.Equal(now, crdbScanner.GetLastModified())
+	r.NoError(waitUntilRunning(ctx, crdbScanner))
+	// Waiting for the 2 metrics to show up.
+	r.NoError(waitForMetrics(ctx, registry, 2))
+	// Refresh again
+	err = scanners.Refresh(stopperCtx)
+	r.NoError(err)
+	// Making sure that the scan is still there
+	crdbScanner, ok = scanners.get(crdbScan.Name)
+	r.True(ok)
+	a.Equal(now, crdbScanner.GetLastModified())
+	// Updating the scan
+	now = time.Now()
+	crdbScan.LastModified.Time = now
+	mockStore.PutScan(ctx, crdbScan)
+	// Refresh
+	err = scanners.Refresh(stopperCtx)
+	r.NoError(err)
+	// Making sure that the scan was updated
+	crdbScanner, ok = scanners.get(crdbScan.Name)
+	r.True(ok)
+	a.Equal(now, crdbScanner.GetLastModified())
+
+	// Adding another scan
+	pebbleTime := time.Now()
+	pebbleScan := &store.Scan{
+		Enabled: true,
+		Format:  store.CRDBV2,
+		LastModified: pgtype.Timestamp{
+			Time:  pebbleTime,
+			Valid: true,
+		},
+		Name: "pebble",
+		Path: "./testdata/pebble.log",
+		Patterns: []store.Pattern{
+			{
+				Name:  "sstable",
+				Regex: "sstable",
+				Help:  "sstable events",
+			},
+		},
+	}
+
+	// Adding the scan to the store
+	mockStore.PutScan(ctx, pebbleScan)
+
+	// Refresh
+	err = scanners.Refresh(stopperCtx)
+	r.NoError(err)
+
+	// Making sure that the crdb scan is still there
+	crdbScanner, ok = scanners.get(crdbScan.Name)
+	r.True(ok)
+	a.Equal(now, crdbScanner.GetLastModified())
+	r.NoError(waitUntilRunning(ctx, crdbScanner))
+	// Making sure that the pebble scan  there
+	pebbleScanner, ok := scanners.get(pebbleScan.Name)
+	r.True(ok)
+	a.Equal(pebbleTime, pebbleScanner.GetLastModified())
+	r.NoError(waitUntilRunning(ctx, pebbleScanner))
+	// Waiting for the additional metric to show up.
+	r.NoError(waitForMetrics(ctx, registry, 3))
+
+	// Removing the crdb log scanner
+	mockStore.DeleteScan(ctx, crdbScan.Name)
+	// Refresh
+	err = scanners.Refresh(stopperCtx)
+	r.NoError(err)
+
+	// Making sure that the crdb scanner is stopped, and pebble is not
+	r.True(crdbScanner.stopped())
+	r.False(pebbleScanner.stopped())
+
+	// Making sure that the crdb scanner is gone
+	crdbScanner, ok = scanners.get(crdbScan.Name)
+	a.False(ok)
+	a.Nil(crdbScanner)
+
+	// Making sure that the pebble scan  there
+	pebbleScanner, ok = scanners.get(pebbleScan.Name)
+	r.True(ok)
+	a.Equal(pebbleTime, pebbleScanner.GetLastModified())
+
+	// Verify that we collected metrics
+	metrics, err := registry.Gather()
+	r.NoError(err)
+	a.Equal(3, len(metrics))
+	for _, m := range metrics {
+		a.Contains([]string{"crdblog_cache", "crdblog_max", "pebble_sstable"}, *m.Name)
+	}
+
+}
+
+func waitForMetrics(ctx context.Context, registry *prometheus.Registry, expected int) error {
+	for {
+		metrics, err := registry.Gather()
+		if err != nil {
+			return err
+		}
+		if len(metrics) == expected {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.Tick(time.Second):
+		}
+	}
+
+}
+func waitUntilRunning(ctx context.Context, scanner *Scanner) error {
+	for scanner.stopped() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.Tick(time.Second):
+		}
+	}
+	return nil
+}

--- a/internal/scanner/testdata/all.txt
+++ b/internal/scanner/testdata/all.txt
@@ -1,0 +1,4 @@
+# HELP crdb_all all events
+# TYPE crdb_all counter
+crdb_all{level="I",source="cli/start.go"} 6
+crdb_all{level="I",source="server/config.go"} 3

--- a/internal/scanner/testdata/cache.txt
+++ b/internal/scanner/testdata/cache.txt
@@ -1,0 +1,3 @@
+# HELP crdb_cache cache events
+# TYPE crdb_cache counter
+crdb_cache{level="I",source="server/config.go"} 1

--- a/internal/scanner/testdata/max.txt
+++ b/internal/scanner/testdata/max.txt
@@ -1,0 +1,3 @@
+# HELP crdb_max max events
+# TYPE crdb_max counter
+crdb_max{level="I",source="server/config.go"} 1

--- a/internal/scanner/testdata/pebble.log
+++ b/internal/scanner/testdata/pebble.log
@@ -1,0 +1,33 @@
+I240514 21:09:45.223164 125 util/log/file_sync_buffer.go:238 ⋮ [config]   file created at: 2024/05/14 21:09:45
+I240514 21:09:45.223171 125 util/log/file_sync_buffer.go:238 ⋮ [config]   running on machine: ‹crlMBP-C02FV1N5MD6TMjk4.local›
+I240514 21:09:45.223178 125 util/log/file_sync_buffer.go:238 ⋮ [config]   binary: CockroachDB CCL v23.1.12 (x86_64-apple-darwin19, built 2023/11/09 06:34:18, go1.19.13)
+I240514 21:09:45.223183 125 util/log/file_sync_buffer.go:238 ⋮ [config]   arguments: [‹cockroach› ‹start-single-node› ‹--insecure› ‹--listen-addr=localhost:26257› ‹--http-addr=localhost:8080›]
+I240514 21:09:45.223192 125 util/log/file_sync_buffer.go:238 ⋮ [config]   log format (utf8=✓): crdb-v2
+I240514 21:09:45.223196 125 util/log/file_sync_buffer.go:238 ⋮ [config]   line format: [IWEF]yymmdd hh:mm:ss.uuuuuu goid [chan@]file:line redactionmark \[tags\] [counter] msg
+I240514 21:09:45.222952 125 3@pebble/event.go:697 ⋮ [n?,s?,pebble] 1  [JOB 1] flushing: sstable created 031355
+I240514 21:09:45.332616 125 3@pebble/event.go:689 ⋮ [n?,s?,pebble] 2  [JOB 1] MANIFEST created 031357
+I240514 21:09:45.352052 125 3@pebble/event.go:717 ⋮ [n?,s?,pebble] 3  [JOB 1] WAL created 031356
+I240514 21:09:45.392242 56 3@pebble/event.go:665 ⋮ [n?,s?,pebble] 4  [JOB 2] compacting(default) L0 [031355] (268 K) + L5 [031347 031348 031349 031350 031351 031352 031353 031354] (20 M)
+I240514 21:09:45.392453 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 5  [JOB 1] WAL deleted 031322
+I240514 21:09:45.394739 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 6  [JOB 1] WAL deleted 031335
+I240514 21:09:45.396186 54 3@pebble/event.go:721 ⋮ [n?,s?,pebble] 7  [JOB 1] WAL deleted 031345
+I240514 21:09:45.401660 54 3@pebble/event.go:693 ⋮ [n?,s?,pebble] 8  [JOB 1] MANIFEST deleted 030960
+I240514 21:09:45.404496 56 3@pebble/event.go:697 ⋮ [n?,s?,pebble] 9  [JOB 2] compacting: sstable created 031359
+I240514 21:09:45.420728 27 3@pebble/event.go:709 ⋮ [n?,s?,pebble] 10  [JOB 4] all initial table stats loaded
+I240514 21:09:45.468735 125 3@pebble/event.go:689 ⋮ [n?,s?,pebble] 11  [JOB 1] MANIFEST created 000001
+I240514 21:09:45.513105 125 3@pebble/event.go:717 ⋮ [n?,s?,pebble] 12  [JOB 1] WAL created 000002
+I240514 21:09:45.582136 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 13  upgraded to format version: ‹002›
+I240514 21:09:45.647154 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 14  upgraded to format version: ‹003›
+I240514 21:09:45.684187 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 15  upgraded to format version: ‹004›
+I240514 21:09:45.723492 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 16  upgraded to format version: ‹005›
+I240514 21:09:45.743039 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 17  upgraded to format version: ‹006›
+I240514 21:09:45.762086 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 18  upgraded to format version: ‹007›
+I240514 21:09:45.782006 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 19  upgraded to format version: ‹008›
+I240514 21:09:45.802019 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 20  upgraded to format version: ‹009›
+I240514 21:09:45.821098 125 3@pebble/event.go:685 ⋮ [n?,s?,pebble] 21  upgraded to format version: ‹010›
+I240514 21:09:45.861105 105 3@pebble/event.go:709 ⋮ [n?,s?,pebble] 22  [JOB 4] all initial table stats loaded
+I240514 21:09:46.047960 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 23  [JOB 2] compacting: sstable created 031360
+I240514 21:09:46.219838 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 24  [JOB 2] compacting: sstable created 031361
+I240514 21:09:46.317406 56 3@pebble/event.go:697 ⋮ [n1,s?,pebble] 25  [JOB 2] compacting: sstable created 031362
+I240514 21:09:46.595958 56 3@pebble/event.go:697 ⋮ [n1,s1,pebble] 26  [JOB 2] compacting: sstable created 031363
+I240514 21:09:47.386998 56 3@pebble/event.go:697 ⋮ [n1,s1,pebble] 27  [JOB 2] compacting: sstable created 031364

--- a/internal/scanner/testdata/regex.txt
+++ b/internal/scanner/testdata/regex.txt
@@ -1,0 +1,3 @@
+# HELP crdb_size size events
+# TYPE crdb_size counter
+crdb_size{level="I",source="server/config.go"} 2

--- a/internal/scanner/testdata/sample.log
+++ b/internal/scanner/testdata/sample.log
@@ -1,0 +1,9 @@
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8  using local environment variables:
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8 +LANG=‹en_US.UTF-8›
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8 +TERM=‹xterm-256color›
+I240418 15:31:56.563621 1 1@cli/start.go:1323 ⋮ [T1,n?] 9  process identity: ‹uid 503 euid 503 gid 20 egid 20›
+I240418 15:31:56.565946 1 1@cli/start.go:1478 ⋮ [T1,n?] 10  GEOS loaded from directory ‹/usr/local/lib/cockroach›
+I240418 15:31:56.565968 1 1@cli/start.go:779 ⋮ [T1,n?] 11  starting cockroach node
+I240418 15:31:56.801319 97 server/config.go:860 ⋮ [T1,n?] 12  1 storage engine initialized
+I240418 15:31:56.801348 97 server/config.go:863 ⋮ [T1,n?] 13  Pebble cache size: 128 MiB
+I240418 15:31:56.801363 97 server/config.go:863 ⋮ [T1,n?] 14  store 0: max size 0 B, max open file limit 117880

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	BindCert, BindKey string        // Paths to Certificate and Key.
 	CaCert            string        // Path to the Root CA.
 	Endpoint          string        // Endpoint for metrics
+	Inotify           bool          // Enable inotify for scans.
 	Insecure          bool          // Sanity check to ensure that the operator really means it.
 	ProcMetrics       bool          // Enable collections of process metrics.
 	Prometheus        string        // URL for the node prometheus endpoint

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachlabs/visus/internal/cmd/collection"
 	"github.com/cockroachlabs/visus/internal/cmd/histogram"
 	"github.com/cockroachlabs/visus/internal/cmd/initialize"
+	"github.com/cockroachlabs/visus/internal/cmd/scan"
 	"github.com/cockroachlabs/visus/internal/cmd/server"
 	"github.com/cockroachlabs/visus/internal/stopper"
 	joonix "github.com/joonix/log"
@@ -94,6 +95,7 @@ func main() {
 
 	root.AddCommand(server.Command())
 	root.AddCommand(collection.Command())
+	root.AddCommand(scan.Command())
 	root.AddCommand(histogram.Command())
 	root.AddCommand(initialize.Command())
 	gracePeriod := 5 * time.Second


### PR DESCRIPTION
This change adds a subcommand to the visus cli to manage scans, allowing users to add/delete/view/test scan configurations in the database.

The configuration is represented in a yaml file, like in the following example:
```
name: cockroach_log
enabled: true
format: crdb-v2
path: /var/logs/cockroach.log
patterns:
  - name : events
    regex:
    help : number of events
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/121)
<!-- Reviewable:end -->
