### PR TITLE
log scanner: adding cli to managing scans.

### DIFF
--- a/internal/cmd/scan/admin.go
+++ b/internal/cmd/scan/admin.go
@@ -1,0 +1,232 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scan defines the sub command to run visus scan utilities.
+package scan
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/cmd/env"
+	"github.com/cockroachlabs/visus/internal/scanner"
+	"github.com/cockroachlabs/visus/internal/stopper"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+	"github.com/spf13/cobra"
+)
+
+var databaseURL = ""
+
+// Command runs the scan tools to view and manage the configuration in the database.
+func Command() *cobra.Command {
+	return command(env.Default())
+}
+
+// command runs the tools to view and manage the configuration in the database.
+// An environment can be injected for standalone testing.
+func command(env *env.Env) *cobra.Command {
+	c := &cobra.Command{
+		Use: "scan",
+	}
+	f := c.PersistentFlags()
+	c.AddCommand(
+		getCmd(env),
+		listCmd(env),
+		deleteCmd(env),
+		putCmd(env),
+		testCmd(env))
+	f.StringVar(&databaseURL, "url", "",
+		"Connection URL, of the form: postgresql://[user[:passwd]@]host[:port]/[db][?parameters...]")
+	return c
+}
+
+// deleteCmd deletes a scan from the database.
+func deleteCmd(env *env.Env) *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan delete scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			scan := args[0]
+			store, err := env.ProvideStore(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			if err := store.DeleteScan(ctx, scan); err != nil {
+				return errors.Wrapf(err, "unable to delete scan %s", scan)
+			}
+			cmd.Printf("Scan %s deleted.\n", scan)
+			return nil
+		},
+	}
+}
+
+// getCmd retrieves a scan configuration from the database.
+func getCmd(env *env.Env) *cobra.Command {
+	return &cobra.Command{
+		Use:     "get",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan get scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			scanName := args[0]
+			store, err := env.ProvideStore(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			scan, err := store.GetScan(ctx, scanName)
+			if err != nil {
+				return errors.Wrapf(err, "unable to retrieve scan %s", scanName)
+			}
+			if scan == nil {
+				cmd.Printf("Scan %s not found\n", scanName)
+				return nil
+			}
+			res, err := marshal(scan)
+			if err != nil {
+				return errors.Wrapf(err, "unable to retrieve scan %s", scanName)
+			}
+			cmd.Print(string(res))
+			return nil
+		},
+	}
+}
+
+// listCmd list all the log scans in the database
+func listCmd(env *env.Env) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Example: `./visus scan list  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			store, err := env.ProvideStore(ctx, databaseURL)
+			if err != nil {
+				return errors.Wrap(err, "unable to retrieve scans")
+			}
+			scans, err := store.GetScanNames(ctx)
+			if err != nil {
+				return errors.Wrap(err, "unable to retrieve scans")
+			}
+			sort.Strings(scans)
+			for _, scan := range scans {
+				cmd.Printf("%s\n", scan)
+			}
+			return nil
+		},
+	}
+}
+
+// putCmd inserts a new scan in the database using the specified yaml configuration.
+func putCmd(env *env.Env) *cobra.Command {
+	var file string
+	c := &cobra.Command{
+		Use:     "put",
+		Args:    cobra.ExactArgs(0),
+		Example: `./visus scan put --yaml config.yaml --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if file == "" {
+				return errors.New("yaml configuration required")
+			}
+			store, err := env.ProvideStore(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			data, err := env.ReadFile(file)
+			if err != nil {
+				return errors.Wrap(err, "unable to read read configuration")
+			}
+			scan, err := unmarshal(data)
+			if err != nil {
+				return errors.Wrap(err, "unable to read scan configuration")
+			}
+			if err := store.PutScan(ctx, scan); err != nil {
+				return errors.Wrapf(err, "unable to insert scan %s", scan.Name)
+			}
+			cmd.Printf("Scan %s inserted.\n", scan.Name)
+			return nil
+		},
+	}
+	f := c.Flags()
+	f.StringVar(&file, "yaml", "", "file containing the configuration")
+	return c
+}
+
+// testCmd retrieves a scan configuration and execute it, returning the metrics extracted
+// from the log file in the scan.
+func testCmd(env *env.Env) *cobra.Command {
+	var interval time.Duration
+	var count int
+	c := &cobra.Command{
+		Use:     "test",
+		Args:    cobra.ExactArgs(1),
+		Example: `./visus scan test scan_name  --url "postgresql://root@localhost:26257/defaultdb?sslmode=disable" `,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := stopper.WithContext(cmd.Context())
+
+			scanName := args[0]
+			store, err := env.ProvideStore(ctx, databaseURL)
+			if err != nil {
+				return err
+			}
+			scan, err := store.GetScan(ctx, scanName)
+			if err != nil {
+				return errors.Wrapf(err, "unable to retrieve scan %s", scanName)
+			}
+			if scan == nil {
+				cmd.Printf("Scan %s not found\n", scanName)
+				return nil
+			}
+
+			scanner, err := scanner.FromConfig(scan,
+				&scanner.Config{
+					FromBeginning: true,
+					Poll:          true,
+					Follow:        false,
+				},
+				prometheus.DefaultRegisterer)
+			if err != nil {
+				return err
+			}
+			scanner.Start(ctx)
+			for i := 1; i <= count || count == 0; i++ {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(interval):
+				}
+				gathering, err := prometheus.DefaultGatherer.Gather()
+				if err != nil {
+					return errors.Wrap(err, "prometheus failure")
+				}
+				cmd.Printf("\n---- %s %s -----\n", time.Now().Format("01-02-2006 15:04:05"), scan.Name)
+				for _, mf := range gathering {
+					if strings.HasPrefix(*mf.Name, scan.Name) {
+						expfmt.MetricFamilyToText(cmd.OutOrStdout(), mf)
+
+					}
+				}
+			}
+			return scanner.Stop()
+		},
+	}
+	f := c.Flags()
+	f.DurationVar(&interval, "interval", 10*time.Second, "interval of scan")
+	f.IntVar(&count, "count", 1, "number of times to run the scan. Specify 0 for continuos scan")
+	return c
+}

--- a/internal/cmd/scan/admin_test.go
+++ b/internal/cmd/scan/admin_test.go
@@ -1,0 +1,215 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scan
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachlabs/visus/internal/cmd/env"
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHelp ensures that the CLI command can be constructed and
+// that all flag binding works.
+func TestHelp(t *testing.T) {
+	r := require.New(t)
+	r.NoError(Command().Help())
+}
+
+type commandTest struct {
+	args               []string
+	expectedError      string
+	expectedOut        string
+	expectedStoreNames []string
+	forcedError        error
+	initialStore       []*store.Scan
+	name               string
+	stdIn              string
+}
+
+func (c *commandTest) execute(ctx context.Context, t *testing.T) {
+	r := require.New(t)
+	a := assert.New(t)
+	env := env.Testing(ctx)
+	st, err := env.ProvideStore(ctx, "")
+	r.NoError(err)
+	for _, scan := range c.initialStore {
+		r.NoError(st.PutScan(ctx, scan))
+	}
+	if c.forcedError != nil {
+		env.InjectStoreError(c.forcedError)
+	}
+	if c.stdIn != "" {
+		env.InjectReader(bytes.NewReader([]byte(c.stdIn)))
+	}
+	out, err := env.TestCommand(command, c.args)
+	if c.expectedError != "" {
+		a.ErrorContains(err, c.expectedError)
+		return
+	}
+	a.Contains(out, c.expectedOut)
+	names, err := st.GetScanNames(ctx)
+	r.NoError(err)
+	slices.Sort(c.expectedStoreNames)
+	a.Equal(c.expectedStoreNames, names)
+}
+
+// TestCommands verifies that the behavior of each CLI command.
+func TestCommands(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r := require.New(t)
+	scan1 := &store.Scan{
+		Name:   "scan_01",
+		Path:   "testdata/sample.log",
+		Format: "crdb-v2",
+		Patterns: []store.Pattern{
+			{
+				Help: "description",
+				Name: "metric",
+			},
+		},
+	}
+	mscan1, err := marshal(scan1)
+	r.NoError(err)
+	scan1Cfg := string(mscan1)
+	scan2 := &store.Scan{Name: "scan_02"}
+	mscan2, err := marshal(scan2)
+	r.NoError(err)
+	scan2Cfg := string(mscan2)
+	scans := []*store.Scan{scan1, scan2}
+	scanNames := []string{"scan_01", "scan_02"}
+	tests := []commandTest{
+		// Delete
+		{
+			args:               []string{"delete", "--url", "fake://", scan1.Name},
+			expectedOut:        fmt.Sprintf("Scan %s deleted.\n", scan1.Name),
+			expectedStoreNames: []string{},
+			initialStore:       []*store.Scan{scan1},
+			name:               "delete scan",
+		},
+		{
+			args:          []string{"delete", "--url", "fake://", scan1.Name},
+			expectedError: "injected error",
+			forcedError:   errors.New("injected error"),
+			initialStore:  []*store.Scan{scan1},
+			name:          "delete scan store error",
+		},
+		// Get
+		{
+			args:               []string{"get", "--url", "fake://", scan1.Name},
+			expectedOut:        scan1Cfg,
+			expectedStoreNames: []string{scan1.Name},
+			initialStore:       []*store.Scan{scan1},
+			name:               "get scan",
+		},
+		{
+			args:               []string{"get", "--url", "fake://", "not_there"},
+			expectedOut:        "not found",
+			expectedStoreNames: []string{scan1.Name},
+			initialStore:       []*store.Scan{scan1},
+			name:               "get not existent scan",
+		},
+		{
+			args:          []string{"get", "--url", "fake://", scan1.Name},
+			expectedError: "injected error",
+			forcedError:   errors.New("injected error"),
+			initialStore:  []*store.Scan{scan1},
+			name:          "get scan store error",
+		},
+		// List
+		{
+			args:               []string{"list", "--url", "fake://"},
+			expectedOut:        strings.Join(scanNames, "\n"),
+			expectedStoreNames: scanNames,
+			initialStore:       scans,
+			name:               "list scan",
+		},
+		{
+			args:          []string{"list", "--url", "fake://", scan1.Name},
+			expectedError: "injected error",
+			forcedError:   errors.New("injected error"),
+			initialStore:  []*store.Scan{scan1},
+			name:          "list scan store error",
+		},
+		// Put
+		{
+			args:               []string{"put", "--url", "fake://", "--yaml", "-"},
+			expectedOut:        fmt.Sprintf("Scan %s inserted.\n", scan2.Name),
+			expectedStoreNames: scanNames,
+			initialStore:       []*store.Scan{scan1},
+			name:               "put scan",
+			stdIn:              scan2Cfg,
+		},
+		{
+			args:          []string{"put", "--url", "fake://", "--yaml"},
+			expectedError: "flag needs an argument",
+			initialStore:  []*store.Scan{scan1},
+			name:          "put scan no yaml arg",
+			stdIn:         scan2Cfg,
+		},
+		{
+			args:          []string{"put", "--url", "fake://"},
+			expectedError: "yaml configuration required",
+			initialStore:  []*store.Scan{scan1},
+			name:          "put scan no yaml flag",
+			stdIn:         scan2Cfg,
+		},
+		{
+			args:          []string{"put", "--url", "fake://", "--yaml", "-"},
+			expectedError: "injected error",
+			forcedError:   errors.New("injected error"),
+			initialStore:  []*store.Scan{scan1},
+			name:          "put scan store error",
+			stdIn:         scan2Cfg,
+		},
+		// Test
+		{
+			args:               []string{"test", "--interval", "1s", "--url", "fake://", scan1.Name},
+			expectedOut:        "HELP scan_01_metric description",
+			expectedStoreNames: []string{scan1.Name},
+			initialStore:       []*store.Scan{scan1},
+			name:               "test scan",
+		},
+		{
+			args:               []string{"test", "--url", "fake://", "not_there"},
+			expectedOut:        "not found",
+			expectedStoreNames: []string{scan1.Name},
+			initialStore:       []*store.Scan{scan1},
+			name:               "test not existent scan",
+		},
+		{
+			args:          []string{"test", "--url", "fake://", scan1.Name},
+			expectedError: "injected error",
+			forcedError:   errors.New("injected error"),
+			initialStore:  []*store.Scan{scan1},
+			name:          "test scan store error",
+		},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			tst.execute(ctx, t)
+		})
+	}
+}

--- a/internal/cmd/scan/testdata/sample.log
+++ b/internal/cmd/scan/testdata/sample.log
@@ -1,0 +1,1 @@
+I240418 15:31:56.563605 1 1@cli/start.go:1316 ⋮ [T1,n?] 8  using local environment variables:

--- a/internal/cmd/scan/yaml.go
+++ b/internal/cmd/scan/yaml.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scan
+
+import (
+	"github.com/cockroachlabs/visus/internal/store"
+	"github.com/creasty/defaults"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// patternDef yaml pattern definition
+type patternDef struct {
+	Help  string
+	Name  string
+	Regex string
+}
+
+// config yaml scan definition
+type config struct {
+	Enabled  bool
+	Format   string
+	Name     string
+	Path     string
+	Patterns []patternDef
+}
+
+func marshal(logFile *store.Scan) ([]byte, error) {
+	patterns := make([]patternDef, 0)
+	for _, m := range logFile.Patterns {
+		metric := patternDef{
+			Help:  m.Help,
+			Name:  m.Name,
+			Regex: m.Regex,
+		}
+		patterns = append(patterns, metric)
+	}
+	config := &config{
+		Enabled:  logFile.Enabled,
+		Format:   string(logFile.Format),
+		Name:     logFile.Name,
+		Path:     logFile.Path,
+		Patterns: patterns,
+	}
+	return yaml.Marshal(config)
+}
+
+func unmarshal(data []byte) (*store.Scan, error) {
+	config := &config{}
+	err := yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, err
+	}
+	if err := defaults.Set(config); err != nil {
+		return nil, err
+	}
+	patterns := make([]store.Pattern, 0)
+	for _, p := range config.Patterns {
+		pattern := store.Pattern{
+			Name:  p.Name,
+			Regex: p.Regex,
+			Help:  p.Help,
+		}
+		patterns = append(patterns, pattern)
+	}
+	if config.Name == "" {
+		return nil, errors.New("name must be specified")
+	}
+	return &store.Scan{
+		Enabled:  config.Enabled,
+		Format:   store.LogFormat(config.Format),
+		Path:     config.Path,
+		Name:     config.Name,
+		Patterns: patterns,
+	}, nil
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachlabs/visus/internal/cmd/collection"
 	"github.com/cockroachlabs/visus/internal/cmd/histogram"
 	"github.com/cockroachlabs/visus/internal/cmd/initialize"
+	"github.com/cockroachlabs/visus/internal/cmd/scan"
 	"github.com/cockroachlabs/visus/internal/cmd/server"
 	"github.com/cockroachlabs/visus/internal/stopper"
 	joonix "github.com/joonix/log"
@@ -94,6 +95,7 @@ func main() {
 
 	root.AddCommand(server.Command())
 	root.AddCommand(collection.Command())
+	root.AddCommand(scan.Command())
 	root.AddCommand(histogram.Command())
 	root.AddCommand(initialize.Command())
 	gracePeriod := 5 * time.Second


### PR DESCRIPTION
This change adds a subcommand to the visus cli to manage scans, allowing users to add/delete/view/test scan configurations in the database.
The configuration is represented in a yaml file, like in the following example:
```
name: cockroach_log
enabled: true
format: crdb-v2
path: /var/logs/cockroach.log
patterns:
  - name : events
    regex:
    help : number of events
```

The README has been updated to describe the new functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/124)
<!-- Reviewable:end -->
