### PR TITLE
collector: moving the metric/server to collector

### DIFF
--- a/internal/cmd/collection/admin.go
+++ b/internal/cmd/collection/admin.go
@@ -166,15 +166,10 @@ func testCmd() *cobra.Command {
 			if coll == nil {
 				fmt.Printf("Collection %s not found\n", collectionName)
 			} else {
-				collector := collector.New(coll.Name, coll.Labels, coll.Query).
-					WithMaxResults(coll.MaxResult)
-				for _, m := range coll.Metrics {
-					switch m.Kind {
-					case store.Gauge:
-						collector.AddGauge(m.Name, m.Help)
-					case store.Counter:
-						collector.AddCounter(m.Name, m.Help)
-					}
+				collector, err := collector.FromCollection(coll, prometheus.DefaultRegisterer)
+				if err != nil {
+					fmt.Printf("Error collecting metrics %s.", err)
+					return err
 				}
 				for i := 1; i <= count || count == 0; i++ {
 					if i > 1 {

--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/field-eng-powertools/stopper"
+	"github.com/cockroachlabs/visus/internal/collector"
 	"github.com/cockroachlabs/visus/internal/database"
 	"github.com/cockroachlabs/visus/internal/http"
-	"github.com/cockroachlabs/visus/internal/metric"
 	"github.com/cockroachlabs/visus/internal/scanner"
 	"github.com/cockroachlabs/visus/internal/server"
 	"github.com/cockroachlabs/visus/internal/store"
@@ -87,12 +87,12 @@ func Command() *cobra.Command {
 				return err
 			}
 
-			// Start the SQL metrics collector.
-			metricServer, err := metric.New(cfg, store, roConn, registry, scheduler)
+			// Start the collector server.
+			collServer, err := collector.New(cfg, store, roConn, registry, scheduler)
 			if err != nil {
 				return err
 			}
-			if err := metricServer.Start(ctx); err != nil {
+			if err := collServer.Start(ctx); err != nil {
 				return err
 			}
 
@@ -118,7 +118,7 @@ func Command() *cobra.Command {
 						// try to continue with the old configuration for
 						// any server that fails.
 						log.Info("Refreshing configuration on SIGHUP")
-						if err := metricServer.Refresh(ctx); err != nil {
+						if err := collServer.Refresh(ctx); err != nil {
 							log.Errorf("refreshing metrics %q", err)
 						}
 						if err := scannerServer.Refresh(ctx); err != nil {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -109,31 +109,6 @@ type cacheValue struct {
 	vec    cacheGC
 }
 
-// New creates a collector with the given name.
-// The labels define the various attributes of the metrics being captured.
-// The query is the SQL query being executed to retrieve the metric values. The query must have an argument
-// to specify the limit on the number results to be returned. The columns must contain the labels specified.
-// The format of the query:
-// (SELECT label1,label2, ..., metric1,metric2,... FROM ... WHERE ... LIMIT $1)
-func New(name string, labels []string, query string) Collector {
-	labelMap := make(map[string]int)
-	for i, l := range labels {
-		labelMap[l] = i
-	}
-	return &collector{
-		enabled:    true,
-		first:      true,
-		frequency:  10,
-		labelMap:   labelMap,
-		labels:     labels,
-		maxResults: 100,
-		metrics:    make(map[string]metric),
-		name:       name,
-		query:      query,
-		registerer: prometheus.DefaultRegisterer,
-	}
-}
-
 // FromCollection creates a collector from a collection configuration stored in the database.
 func FromCollection(coll *store.Collection, registerer prometheus.Registerer) (Collector, error) {
 	labelMap := make(map[string]int)

--- a/internal/collector/server.go
+++ b/internal/collector/server.go
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package metric retrieves metric values on a schedule.
-package metric
+package collector
 
 import (
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/field-eng-powertools/stopper"
-	"github.com/cockroachlabs/visus/internal/collector"
 	"github.com/cockroachlabs/visus/internal/database"
 	"github.com/cockroachlabs/visus/internal/server"
 	"github.com/cockroachlabs/visus/internal/store"
@@ -60,12 +58,12 @@ var (
 )
 
 type scheduledJob struct {
-	collector collector.Collector
+	collector Collector
 	job       *gocron.Job
 }
 
-// Config defines the metrics to be retrieved from the metricsServer
-type metricsServer struct {
+// serverImpl manages the collections.
+type serverImpl struct {
 	config    *server.Config
 	conn      database.Connection
 	registry  *prometheus.Registry
@@ -79,7 +77,7 @@ type metricsServer struct {
 	}
 }
 
-// New creates a new server to collect the metrics.
+// New creates a new server to collect the metrics defined in the collections.
 func New(
 	cfg *server.Config,
 	store store.Store,
@@ -100,7 +98,7 @@ func New(
 	if cfg.ProcMetrics {
 		registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	}
-	server := &metricsServer{
+	server := &serverImpl{
 		config:    cfg,
 		conn:      conn,
 		registry:  registry,
@@ -113,9 +111,9 @@ func New(
 }
 
 // Refresh implements server.Server
-func (m *metricsServer) Refresh(ctx *stopper.Context) error {
+func (s *serverImpl) Refresh(ctx *stopper.Context) error {
 	log.Info("Refreshing metrics collector configuration")
-	err := m.refresh(ctx)
+	err := s.refresh(ctx)
 	if err != nil {
 		server.RefreshErrors.WithLabelValues("metric_collector").Inc()
 	}
@@ -123,15 +121,15 @@ func (m *metricsServer) Refresh(ctx *stopper.Context) error {
 	return nil
 }
 
-// Start schedules all the collectors.
-func (m *metricsServer) Start(ctx *stopper.Context) error {
+// Start implements server.Server.
+func (s *serverImpl) Start(ctx *stopper.Context) error {
 	// If we don't have a scheduler, we force a refresh and we are done.
-	if m.scheduler == nil {
-		return m.Refresh(ctx)
+	if s.scheduler == nil {
+		return s.Refresh(ctx)
 	}
-	_, err := m.scheduler.Every(m.config.Refresh).
+	_, err := s.scheduler.Every(s.config.Refresh).
 		Do(func() {
-			err := m.Refresh(ctx)
+			err := s.Refresh(ctx)
 			if err != nil {
 				log.Errorf("Error refreshing metrics %s", err.Error())
 			}
@@ -140,51 +138,51 @@ func (m *metricsServer) Start(ctx *stopper.Context) error {
 }
 
 // addJob add a new collector to the scheduler.
-func (m *metricsServer) addJob(name string, coll collector.Collector, job *gocron.Job) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.mu.scheduledJobs[name] = &scheduledJob{
+func (s *serverImpl) addJob(name string, coll Collector, job *gocron.Job) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.scheduledJobs[name] = &scheduledJob{
 		collector: coll,
 		job:       job,
 	}
 }
 
 // cleanupJobs removes all the jobs that we don't need to keep.
-func (m *metricsServer) cleanupJobs(toKeep map[string]bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for key, value := range m.mu.scheduledJobs {
+func (s *serverImpl) cleanupJobs(toKeep map[string]bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, value := range s.mu.scheduledJobs {
 		if _, ok := toKeep[key]; !ok {
 			log.Infof("Removing collector: %s", key)
-			m.scheduler.RemoveByReference(value.job)
+			s.scheduler.RemoveByReference(value.job)
 			value.collector.Unregister()
-			delete(m.mu.scheduledJobs, key)
+			delete(s.mu.scheduledJobs, key)
 		}
 	}
 }
 
 // getJob the named job.
-func (m *metricsServer) getJob(name string) (*scheduledJob, bool) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	job, ok := m.mu.scheduledJobs[name]
+func (s *serverImpl) getJob(name string) (*scheduledJob, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	job, ok := s.mu.scheduledJobs[name]
 	return job, ok
 }
 
-func (m *metricsServer) refresh(ctx *stopper.Context) error {
+func (s *serverImpl) refresh(ctx *stopper.Context) error {
 	newCollectors := make(map[string]bool)
-	names, err := m.store.GetCollectionNames(ctx)
+	names, err := s.store.GetCollectionNames(ctx)
 	if err != nil {
 		return err
 	}
 	log.Info("Refreshing metrics")
-	last := time.Now().UTC().Add(-m.config.Refresh)
-	isMainNode, err := m.store.IsMainNode(ctx, last)
+	last := time.Now().UTC().Add(-s.config.Refresh)
+	isMainNode, err := s.store.IsMainNode(ctx, last)
 	if err != nil {
 		return err
 	}
 	for _, name := range names {
-		coll, err := m.store.GetCollection(ctx, name)
+		coll, err := s.store.GetCollection(ctx, name)
 		if err != nil {
 			log.Errorf("Unable to find %s: %s", name, err.Error())
 			continue
@@ -194,34 +192,34 @@ func (m *metricsServer) refresh(ctx *stopper.Context) error {
 			continue
 		}
 		newCollectors[name] = true
-		existing, found := m.getJob(coll.Name)
+		existing, found := s.getJob(coll.Name)
 		if found && !existing.collector.GetLastModified().Before(coll.LastModified.Time) {
 			log.Debugf("Already scheduled %s", coll.Name)
 			continue
 		}
 		if found {
 			log.Infof("Configuration for %s has changed", coll.Name)
-			m.scheduler.RemoveByReference(existing.job)
+			s.scheduler.RemoveByReference(existing.job)
 		}
-		collctr, err := collector.FromCollection(coll, m.registry)
+		collctr, err := FromCollection(coll, s.registry)
 		if err != nil {
 			log.Errorf("Error scheduling collector %s: %s", name, err.Error())
 			continue
 		}
 		log.Infof("Scheduling collector %s every %d seconds", collctr.String(), collctr.GetFrequency())
-		job, err := m.scheduler.Every(collctr.GetFrequency()).Second().
-			Do(func(collctr collector.Collector) {
+		job, err := s.scheduler.Every(collctr.GetFrequency()).Second().
+			Do(func(collctr Collector) {
 				name := collctr.String()
 				log.Tracef("Running collector %s", name)
 				start := time.Now()
-				err := collctr.Collect(ctx, m.conn)
+				err := collctr.Collect(ctx, s.conn)
 				if err != nil {
-					if m.config.VisusMetrics {
+					if s.config.VisusMetrics {
 						collectorErrors.WithLabelValues(name).Inc()
 					}
 					log.Errorf("collector %s: %s", collctr, err.Error())
 				}
-				if m.config.VisusMetrics {
+				if s.config.VisusMetrics {
 					elapsed := time.Since(start).Milliseconds()
 					collectorLatency.WithLabelValues(name).Observe(float64(elapsed))
 					collectorCounts.WithLabelValues(name).Inc()
@@ -231,8 +229,8 @@ func (m *metricsServer) refresh(ctx *stopper.Context) error {
 			log.Errorf("error scheduling collector %s: %s", coll.Name, err.Error())
 			continue
 		}
-		m.addJob(coll.Name, collctr, job)
+		s.addJob(coll.Name, collctr, job)
 	}
-	m.cleanupJobs(newCollectors)
+	s.cleanupJobs(newCollectors)
 	return nil
 }

--- a/internal/collector/server_test.go
+++ b/internal/collector/server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metric
+package collector
 
 import (
 	"context"
@@ -52,7 +52,7 @@ func TestRefreshCollectors(t *testing.T) {
 	mockStore.Init(ctx)
 	cfg := &server.Config{}
 	registry := prometheus.NewRegistry()
-	server := &metricsServer{
+	server := &serverImpl{
 		config:    cfg,
 		conn:      conn,
 		store:     mockStore,


### PR DESCRIPTION
This change moves the package metric to the collector package, to be consistent with the scanner.

This change also cleans up the Collector constructors, now exporting only the `FromCollection()` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/131)
<!-- Reviewable:end -->
