### PR TITLE
collection: Fix unregistering metrics from Prometheus registry

### DIFF
--- a/internal/cmd/collection/admin.go
+++ b/internal/cmd/collection/admin.go
@@ -70,7 +70,7 @@ func deleteCmd(env *env.Env) *cobra.Command {
 				return err
 			}
 			if err := store.DeleteCollection(ctx, collection); err != nil {
-				return errors.Wrapf(err, "unable to delete scan %s", collection)
+				return errors.Wrapf(err, "unable to delete collection %s", collection)
 			}
 			cmd.Printf("Collection %s deleted.\n", collection)
 			return nil

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -258,7 +258,10 @@ func (c *collector) String() string {
 }
 func (c *collector) Unregister() {
 	for _, metric := range c.metrics {
-		prometheus.Unregister(metric.vec)
+		if !c.registerer.Unregister(metric.vec) {
+			log.Errorf("failed to unregister %s", metric.name)
+		}
+		log.Tracef("unregistering %s", metric.name)
 	}
 }
 


### PR DESCRIPTION
This change corrects a bug where we were attempting to unregister a collector's metrics from the default
Prometheus registry. This was incorrect as we are now using a dedicated registry. This update ensures that the metrics are properly unregistered from the correct, custom registry.

Fixes #207.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/208)
<!-- Reviewable:end -->
