### PR TITLE
collector: fix gauge label cleanup timing

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -55,23 +55,25 @@ type Collector interface {
 
 // collector implementation. To reduce the cardinality of the metrics, it keeps a cache
 // of metrics
+// TODO(silvano): refactor to use a more efficient data structure. Many of these
+// members could be retrieved from the *store.Collection.
 type collector struct {
-	name         string
-	lastModified time.Time
-	cardinality  int
-	enabled      bool
-	frequency    int
-	labels       []string
-	labelMap     map[string]int
-	metrics      map[string]metric
-	databases    string
-	query        string
-	first        bool
-	metricsCache *lru.Cache
-	gauges       map[string]map[string][]string
-	maxResults   int
-	registerer   prometheus.Registerer
-	mu           struct {
+	name                string
+	countersCache       *lru.Cache
+	countersCardinality int
+	databases           string
+	enabled             bool
+	first               bool
+	frequency           int
+	gaugeLabels         map[string]map[string][]string
+	labelMap            map[string]int
+	labels              []string
+	lastModified        time.Time
+	maxResults          int
+	metrics             map[string]metric
+	query               string
+	registerer          prometheus.Registerer
+	mu                  struct {
 		sync.Mutex
 		inUse bool
 	}
@@ -153,7 +155,7 @@ func FromCollection(coll *store.Collection, registerer prometheus.Registerer) (C
 
 // AddCounter adds a metric counter. The name must match one of the columns returned by the query.
 func (c *collector) AddCounter(name string, help string) error {
-	c.cardinality++
+	c.countersCardinality++
 	metricName := c.name + "_" + name
 	vec := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -179,7 +181,6 @@ func (c *collector) AddCounter(name string, help string) error {
 
 // AddGauge adds a metric gauge. The name must match one of the columns returned by the query.
 func (c *collector) AddGauge(name string, help string) error {
-	c.cardinality++
 	metricName := c.name + "_" + name
 	vec := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -394,7 +395,7 @@ func (c *collector) counterAdd(
 		return
 	}
 	var delta float64
-	v, ok := c.metricsCache.Get(key)
+	v, ok := c.countersCache.Get(key)
 	if ok {
 		cv, _ := v.(cacheValue)
 		if cv.value > value {
@@ -406,19 +407,14 @@ func (c *collector) counterAdd(
 		delta = value
 	}
 	vec.WithLabelValues(labels...).Add(delta)
-	c.metricsCache.Add(key, cacheValue{labels, value, vec})
+	c.countersCache.Add(key, cacheValue{labels, value, vec})
 }
 
 // gaugeSet sets a gauge value.
 func (c *collector) gaugeSet(
 	vec *prometheus.GaugeVec, name string, labels []string, value float64,
 ) {
-	key, err := c.getKey(name, labels)
-	if err != nil {
-		return
-	}
 	vec.WithLabelValues(labels...).Set(value)
-	c.metricsCache.Add(key, cacheValue{labels, value, vec})
 }
 
 func (c *collector) getAllLabels() []string {
@@ -444,23 +440,26 @@ func (c *collector) getKey(name string, labels []string) (string, error) {
 // clearObsoleteGauges removes the metrics for labels that are no longer present.
 // This is required to prevent obsolete metrics from being reported.
 func (c *collector) clearObsoleteGauges(currGauges map[string]map[string][]string) {
-	for colName, labels := range c.gauges {
+	for gaugeName, labels := range c.gaugeLabels {
 		for id, lbs := range labels {
-			if _, ok := currGauges[colName][id]; ok {
+			if _, ok := currGauges[gaugeName][id]; ok {
 				continue
 			}
-			metric := c.metrics[colName]
+			metric, ok := c.metrics[gaugeName]
+			if !ok {
+				continue
+			}
 			vec := metric.vec.(*prometheus.GaugeVec)
 			vec.DeleteLabelValues(lbs...)
 		}
 	}
-	c.gauges = currGauges
+	c.gaugeLabels = currGauges
 }
 
 func (c *collector) maybeInitCache() {
-	if c.metricsCache == nil {
-		c.metricsCache = lru.New(c.cardinality * c.maxResults * 2)
-		c.metricsCache.OnEvicted = func(key lru.Key, value interface{}) {
+	if c.countersCache == nil {
+		c.countersCache = lru.New(c.countersCardinality * c.maxResults * 2)
+		c.countersCache.OnEvicted = func(key lru.Key, value interface{}) {
 			labels := value.(cacheValue).labels
 			vec := value.(cacheValue).vec
 			vec.DeleteLabelValues(labels...)

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -155,11 +155,11 @@ func TestCollect(t *testing.T) {
 	r.NoError(err)
 	collector := coll.(*collector)
 	collector.maybeInitCache()
-	r.Equal(8, collector.metricsCache.MaxEntries)
-	r.Equal(0, collector.metricsCache.Len())
+	r.Equal(4, collector.countersCache.MaxEntries)
+	r.Equal(0, collector.countersCache.Len())
 	tests := []test{
 		{
-			"one",
+			"start",
 			[]sample{
 				{"test1", 1, 1},
 				{"test2", 1, 5},
@@ -168,10 +168,10 @@ func TestCollect(t *testing.T) {
 				counterMetricName: {"label:test1 1.000000", "label:test2 1.000000"},
 				gaugeMetricName:   {"label:test1 1.000000", "label:test2 5.000000"},
 			},
-			4,
+			2,
 		},
 		{
-			"two",
+			"counter_increase",
 			[]sample{
 				{"test1", 1, 3},
 				{"test2", 1, 1},
@@ -180,10 +180,10 @@ func TestCollect(t *testing.T) {
 				counterMetricName: {"label:test1 1.000000", "label:test2 1.000000"},
 				gaugeMetricName:   {"label:test1 3.000000", "label:test2 1.000000"},
 			},
-			4,
+			2,
 		},
 		{
-			"three",
+			"counter_increase_again",
 			[]sample{
 				{"test1", 4, 1},
 				{"test2", 2, 1},
@@ -192,10 +192,10 @@ func TestCollect(t *testing.T) {
 				counterMetricName: {"label:test1 4.000000", "label:test2 2.000000"},
 				gaugeMetricName:   {"label:test1 1.000000", "label:test2 1.000000"},
 			},
-			4,
+			2,
 		},
 		{
-			"four_counter_reset",
+			"counter_reset",
 			[]sample{
 				{"test1", 2, 1},
 				{"test3", 2, 1},
@@ -204,10 +204,10 @@ func TestCollect(t *testing.T) {
 				counterMetricName: {"label:test1 6.000000", "label:test2 2.000000", "label:test3 2.000000"},
 				gaugeMetricName:   {"label:test1 1.000000", "label:test3 1.000000"},
 			},
-			6,
+			3,
 		},
 		{
-			"five",
+			"new_labels",
 			[]sample{
 				{"test1", 2, 1},
 				{"test4", 2, 1},
@@ -216,10 +216,10 @@ func TestCollect(t *testing.T) {
 				counterMetricName: {"label:test1 6.000000", "label:test2 2.000000", "label:test3 2.000000", "label:test4 2.000000"},
 				gaugeMetricName:   {"label:test1 1.000000", "label:test4 1.000000"},
 			},
-			8,
+			4,
 		},
 		{
-			"six_test2_evicted",
+			"test2_evicted",
 			[]sample{
 				{"test1", 2, 1},
 				{"test5", 2, 1},
@@ -228,9 +228,10 @@ func TestCollect(t *testing.T) {
 				counterMetricName: {"label:test1 6.000000", "label:test3 2.000000", "label:test4 2.000000", "label:test5 2.000000"},
 				gaugeMetricName:   {"label:test1 1.000000", "label:test5 1.000000"},
 			},
-			8,
+			4,
 		},
 	}
+	// run sequentially only
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCollect(t, collector, mock, tt.samples)
@@ -240,12 +241,12 @@ func TestCollect(t *testing.T) {
 				expectedGaugeLabels[i] = s.label
 			}
 			var actualGaugeLabels []string
-			for k := range collector.gauges[gauge] {
+			for k := range collector.gaugeLabels[gauge] {
 				actualGaugeLabels = append(actualGaugeLabels, k)
 			}
 			a.ElementsMatch(expectedGaugeLabels,
 				actualGaugeLabels)
-			a.Equal(tt.cacheLen, collector.metricsCache.Len())
+			a.Equal(tt.cacheLen, collector.countersCache.Len())
 		})
 	}
 }
@@ -270,11 +271,11 @@ func TestDatabaseCollect(t *testing.T) {
 	r.NoError(err)
 	collector := coll.(*collector)
 	collector.maybeInitCache()
-	r.Equal(8, collector.metricsCache.MaxEntries)
-	r.Equal(0, collector.metricsCache.Len())
+	r.Equal(4, collector.countersCache.MaxEntries)
+	r.Equal(0, collector.countersCache.Len())
 	tests := []test{
 		{
-			"one",
+			"start",
 			[]sample{
 				{"test1", 1, 1},
 				{"test2", 1, 5},
@@ -283,10 +284,10 @@ func TestDatabaseCollect(t *testing.T) {
 				counterMetricName: {"_database:mydb,label:test1 1.000000", "_database:mydb,label:test2 1.000000"},
 				gaugeMetricName:   {"_database:mydb,label:test1 1.000000", "_database:mydb,label:test2 5.000000"},
 			},
-			4,
+			2,
 		},
 		{
-			"two",
+			"counter_increase",
 			[]sample{
 				{"test1", 1, 3},
 				{"test2", 1, 1},
@@ -295,10 +296,10 @@ func TestDatabaseCollect(t *testing.T) {
 				counterMetricName: {"_database:mydb,label:test1 1.000000", "_database:mydb,label:test2 1.000000"},
 				gaugeMetricName:   {"_database:mydb,label:test1 3.000000", "_database:mydb,label:test2 1.000000"},
 			},
-			4,
+			2,
 		},
 		{
-			"three",
+			"counter_increase_again",
 			[]sample{
 				{"test1", 4, 1},
 				{"test2", 2, 1},
@@ -307,10 +308,10 @@ func TestDatabaseCollect(t *testing.T) {
 				counterMetricName: {"_database:mydb,label:test1 4.000000", "_database:mydb,label:test2 2.000000"},
 				gaugeMetricName:   {"_database:mydb,label:test1 1.000000", "_database:mydb,label:test2 1.000000"},
 			},
-			4,
+			2,
 		},
 		{
-			"four_counter_reset",
+			"counter_reset",
 			[]sample{
 				{"test1", 2, 1},
 				{"test3", 2, 1},
@@ -319,10 +320,10 @@ func TestDatabaseCollect(t *testing.T) {
 				counterMetricName: {"_database:mydb,label:test1 6.000000", "_database:mydb,label:test2 2.000000", "_database:mydb,label:test3 2.000000"},
 				gaugeMetricName:   {"_database:mydb,label:test1 1.000000", "_database:mydb,label:test3 1.000000"},
 			},
-			6,
+			3,
 		},
 		{
-			"five",
+			"new_labels",
 			[]sample{
 				{"test1", 2, 1},
 				{"test4", 2, 1},
@@ -331,10 +332,10 @@ func TestDatabaseCollect(t *testing.T) {
 				counterMetricName: {"_database:mydb,label:test1 6.000000", "_database:mydb,label:test2 2.000000", "_database:mydb,label:test3 2.000000", "_database:mydb,label:test4 2.000000"},
 				gaugeMetricName:   {"_database:mydb,label:test1 1.000000", "_database:mydb,label:test4 1.000000"},
 			},
-			8,
+			4,
 		},
 		{
-			"six_test2_evicted",
+			"test2_evicted",
 			[]sample{
 				{"test1", 2, 1},
 				{"test5", 2, 1},
@@ -343,20 +344,21 @@ func TestDatabaseCollect(t *testing.T) {
 				counterMetricName: {"_database:mydb,label:test1 6.000000", "_database:mydb,label:test3 2.000000", "_database:mydb,label:test4 2.000000", "_database:mydb,label:test5 2.000000"},
 				gaugeMetricName:   {"_database:mydb,label:test1 1.000000", "_database:mydb,label:test5 1.000000"},
 			},
-			8,
+			4,
 		},
 	}
+	// run sequentially only
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testDatabaseCollect(t, collector, mock, tt.samples)
 			testVerify(t, prefix, tt.expected)
-			a.Equal(tt.cacheLen, collector.metricsCache.Len())
+			a.Equal(tt.cacheLen, collector.countersCache.Len())
 			expectedGaugeLabels := make([]string, len(tt.samples))
 			for i, s := range tt.samples {
 				expectedGaugeLabels[i] = fmt.Sprintf("%s|%s", s.label, dbName)
 			}
 			var actualGaugeLabels []string
-			for k := range collector.gauges[gauge] {
+			for k := range collector.gaugeLabels[gauge] {
 				actualGaugeLabels = append(actualGaugeLabels, k)
 			}
 			a.ElementsMatch(expectedGaugeLabels, actualGaugeLabels)


### PR DESCRIPTION
Previously, gauges were cleared of all labels before re-running the query to repopulate them. This caused gaps for scrapers hitting the Prometheus endpoint between label removal and repopulation.

Now, only labels that are no longer present are removed, and this cleanup happens after refreshing the current metrics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachlabs/visus/219)
<!-- Reviewable:end -->
