### PR TITLE
gomod: consolidate dependency bumps from open PRs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG VERSION=""
 RUN echo "version $VERSION"
 WORKDIR /tmp/compile

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/cockroachlabs/visus
 
-go 1.25.8
+go 1.26.2
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/cockroachdb/cockroach-go/v2 v2.4.3
-	github.com/cockroachdb/crlfmt v0.3.0
-	github.com/cockroachdb/errors v1.12.0
+	github.com/cockroachdb/crlfmt v0.4.0
+	github.com/cockroachdb/errors v1.13.0
 	github.com/cockroachdb/field-eng-powertools v0.2.0
 	github.com/creasty/defaults v1.8.0
 	github.com/go-co-op/gocron v1.37.0
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/getsentry/sentry-go v0.27.0 // indirect
+	github.com/getsentry/sentry-go v0.46.0 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -428,10 +428,10 @@ github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/cockroach-go/v2 v2.4.3 h1:LJO3K3jC5WXvMePRQSJE1NsIGoFGcEx1LW83W6RAlhw=
 github.com/cockroachdb/cockroach-go/v2 v2.4.3/go.mod h1:9U179XbCx4qFWtNhc7BiWLPfuyMVQ7qdAhfrwLz1vH0=
-github.com/cockroachdb/crlfmt v0.3.0 h1:IaPIlidTHn7s493ozBcpnkF/HNzCNe7aBJmUMqgIlOk=
-github.com/cockroachdb/crlfmt v0.3.0/go.mod h1:iRZvVcb8vDQK4dh64mPRZBucM85Xd/VLTE0cmO95/Kk=
-github.com/cockroachdb/errors v1.12.0 h1:d7oCs6vuIMUQRVbi6jWWWEJZahLCfJpnJSVobd1/sUo=
-github.com/cockroachdb/errors v1.12.0/go.mod h1:SvzfYNNBshAVbZ8wzNc/UPK3w1vf0dKDUP41ucAIf7g=
+github.com/cockroachdb/crlfmt v0.4.0 h1:8KMp0zE54aDoUKg37JEhBueymXVeIWBWNFdK+5VATWY=
+github.com/cockroachdb/crlfmt v0.4.0/go.mod h1:SFo0GOnzviaana5OLUxLB454Bf5gyXwlRc+zabXYXyk=
+github.com/cockroachdb/errors v1.13.0 h1:BoCcJeiP9hpBJDETkX19qi8Tb8So37srSsp3stTaDMQ=
+github.com/cockroachdb/errors v1.13.0/go.mod h1:bjxt/4E5+OyuAnacpTIU9rn2mzPu1VlthvHP+xpROq0=
 github.com/cockroachdb/field-eng-powertools v0.2.0 h1:9S+2hQXexZg24PP3Und9SRUWZUcojFeO5eerkNy/TWk=
 github.com/cockroachdb/field-eng-powertools v0.2.0/go.mod h1:+EhiP+YyVFPWlDKf+NaMfeDVOUBbFX6T0dk2VohoHHQ=
 github.com/cockroachdb/gostdlib v1.19.0 h1:cSISxkVnTlWhTkyple/T6NXzOi5659FkhxvUgZv+Eb0=
@@ -462,8 +462,8 @@ github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
-github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
-github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go v0.46.0 h1:mbdDaarbUdOt9X+dx6kDdntkShLEX3/+KyOsVDTPDj0=
+github.com/getsentry/sentry-go v0.46.0/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-co-op/gocron v1.37.0 h1:ZYDJGtQ4OMhTLKOKMIch+/CY70Brbb1dGdooLEhh7b0=
 github.com/go-co-op/gocron v1.37.0/go.mod h1:3L/n6BkO7ABj+TrfSVXLRzsP26zmikL4ISkLQ0O8iNY=


### PR DESCRIPTION
## Summary

Consolidates open go.mod dependency bump PRs into a single change.

### Modules bumped

| Module | From | To |
|--------|------|----|
| `github.com/cockroachdb/errors` | v1.12.0 | v1.13.0 |
| `github.com/cockroachdb/crlfmt` | v0.3.0 | v0.4.0 |
| `github.com/getsentry/sentry-go` (indirect) | v0.27.0 | v0.46.0 |
| Go directive | 1.25.8 | 1.26.2 |

### Other changes

- Updated `Dockerfile` from `golang:1.25` to `golang:1.26`

### Consolidated PRs

- #261 - gomod: bump github.com/cockroachdb/crlfmt from 0.3.0 to 0.4.0
- #264 - gomod: bump github.com/cockroachdb/errors from 1.12.0 to 1.13.0

### Excluded PRs

- #217 - Add an example for Follower Reads (not a go.mod PR)