### PR TITLE
database: ping pool after creation to verify connectivity

### DIFF
--- a/internal/database/factory.go
+++ b/internal/database/factory.go
@@ -53,8 +53,6 @@ func new(ctx context.Context, URL string, ro bool, allowUnsafeInternals bool) (*
 func pgxPool(
 	ctx context.Context, URL string, ro bool, allowUnsafeInternals bool,
 ) (*pgxpool.Pool, error) {
-	var pool *pgxpool.Pool
-	sleepTime := int64(5)
 	poolConfig, err := pgxpool.ParseConfig(URL)
 	if err != nil {
 		log.Fatal(err)
@@ -76,24 +74,38 @@ func pgxPool(
 			return nil
 		}
 	}
+	sleepTime := int64(5)
 	for {
-		pool, err = pgxpool.NewWithConfig(ctx, poolConfig)
-		if err != nil {
-			log.Error(err)
-			log.Warnf("Unable to connect to the db. Retrying in %d seconds", sleepTime)
-			err := sleep(ctx, sleepTime)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			break
+		pool, err := connectAndPing(ctx, poolConfig)
+		if err == nil {
+			log.Debugf("new pool %s (readonly: %t)", poolConfig.ConnString(), ro)
+			return pool, nil
+		}
+		log.Error(err)
+		log.Warnf("Unable to connect to the db. Retrying in %d seconds", sleepTime)
+		if err := sleep(ctx, sleepTime); err != nil {
+			return nil, err
 		}
 		if sleepTime < int64(60) {
 			sleepTime += int64(5)
 		}
 	}
-	log.Debugf("new pool %s (readonly: %t)", poolConfig.ConnString(), ro)
-	return pool, err
+}
+
+// connectAndPing creates a new pool and verifies the database is reachable.
+// pgxpool.NewWithConfig is lazy and does not open a connection, so a ping is
+// required to surface connectivity failures eagerly. The returned pool is
+// closed if the ping fails.
+func connectAndPing(ctx context.Context, cfg *pgxpool.Config) (*pgxpool.Pool, error) {
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, err
+	}
+	return pool, nil
 }
 
 func sleep(ctx context.Context, seconds int64) error {

--- a/internal/database/factory_test.go
+++ b/internal/database/factory_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewPingsUnreachableDatabase verifies that New fails when the database is
+// not reachable. pgxpool.NewWithConfig is lazy and does not open a connection,
+// so without the ping check New would return a "successful" pool pointing at an
+// unreachable host. The test reserves a TCP port and immediately releases it so
+// the URL is syntactically valid but no server is listening.
+func TestNewPingsUnreachableDatabase(t *testing.T) {
+	r := require.New(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	r.NoError(err)
+	addr := listener.Addr().(*net.TCPAddr)
+	r.NoError(listener.Close())
+
+	url := "postgres://test@" + addr.String() + "/test?sslmode=disable&connect_timeout=1"
+
+	// Context expires before the retry backoff has a chance to grow, so the
+	// test stays fast even though the retry loop is exercised.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	pool, err := New(ctx, url)
+	r.Error(err)
+	r.Nil(pool)
+}


### PR DESCRIPTION
  pgxpool.NewWithConfig is lazy and does not open a connection, so the
  existing retry loop in pgxPool only caught configuration errors — a
  "successfully" created pool could still point at an unreachable host,
  with the failure only surfacing on the first real query.

  Call pool.Ping after NewWithConfig succeeds and close the pool if the
  ping fails. Failures flow through the existing retry-with-backoff loop,
  so Refresh gets the same check for free. Extract the single attempt
  into a connectAndPing helper so the loop has a single error path.

  Add TestNewPingsUnreachableDatabase, which points New at a closed local
  TCP port with a short context and verifies the call fails — without the
  ping, the lazy pool creation would have returned success.